### PR TITLE
Make installer script

### DIFF
--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -1,0 +1,31 @@
+name: Github Actions for Conda build
+on: 
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  build-tar:
+    steps:
+      - users: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          installer-url: https://github.com/conda/conda-forge/miniforge/releases/lateset/download/Miniforge3-Linux-x86_64.sh
+      - name: build conda package
+        run: conda build --quiet -c conda-forge conda-build
+        timeout-minutes: 30
+      - name: Initialize shell
+        run: conda init bash
+      - name: Build Installer
+        timeout-minutes: 30
+        run: |
+          conda create -n constructor -c defaults constructor
+          conda activate constructor
+          constructor .
+      - name: Create release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: Ot2Rec-*
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -11,21 +11,22 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          activate-environment: o2rbuild
+          auto-activate-base: true
+          activate-environment: ""
       - name: build conda package
         run: |
           conda install -c conda-forge conda-build conda-verify
           conda build --quiet -c conda-forge conda-build
         timeout-minutes: 30
-      - name: Initalise conda
-        timeout-minutes: 30
-        run: |
+      - name: initialise conda shell
+        run:
           conda init bash
-          exec bash
       - name: Build Installer
         run: |
-          conda create -n constructor -c defaults constructor
-          conda activate constructor
+          conda install constructor
+          conda activate
+          conda info
+          conda list
           constructor .
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -13,15 +13,16 @@ jobs:
           miniconda-version: "latest"
           activate-environment: o2rbuild
       - name: build conda package
-        run: conda build --quiet -c conda-forge conda-build
+        run: |
+          conda install conda-build
+          conda build --quiet -c conda-forge conda-build
         timeout-minutes: 30
       - name: Initialize shell
         run: conda init bash
       - name: Build Installer
         timeout-minutes: 30
         run: |
-          conda create -n constructor -c defaults constructor
-          conda activate constructor
+          conda install constructor
           constructor .
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -14,15 +14,15 @@ jobs:
           activate-environment: o2rbuild
       - name: build conda package
         run: |
-          conda install conda-build
+          conda install -c conda-forge conda-build conda-verify
           conda build --quiet -c conda-forge conda-build
         timeout-minutes: 30
-      - name: Initialize shell
-        run: conda init bash
       - name: Build Installer
         timeout-minutes: 30
         run: |
-          conda install constructor
+          conda create -n constructor -c defaults constructor
+          conda init bash
+          conda activate constructor
           constructor .
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -22,8 +22,8 @@ jobs:
           conda activate constructor
           constructor .
       - name: Create release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: Ot2Rec-*
         env:

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -4,13 +4,14 @@ on:
     tags:
       - 'v*.*.*'
 jobs:
-  build-tar:
+  build-conda-installer:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          installer-url: https://github.com/conda-forge/miniforge/releases/tag/4.10.3-7/Miniforge3-4.10.3-7-Linux-x86_64.sh
+          miniconda-version: "latest"
+          activate-environment: o2rbuild
       - name: build conda package
         run: conda build --quiet -c conda-forge conda-build
         timeout-minutes: 30

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -5,9 +5,9 @@ on:
       - 'v*.*.*'
 jobs:
   build-tar:
-    runs_on: ubuntu_latest
+    runs-on: ubuntu-20.04
     steps:
-      - users: actions/checkout@v2
+      - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
           installer-url: https://github.com/conda/conda-forge/miniforge/releases/lateset/download/Miniforge3-Linux-x86_64.sh

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -17,11 +17,14 @@ jobs:
           conda install -c conda-forge conda-build conda-verify
           conda build --quiet -c conda-forge conda-build
         timeout-minutes: 30
-      - name: Build Installer
+      - name: Initalise conda
         timeout-minutes: 30
         run: |
-          conda create -n constructor -c defaults constructor
           conda init bash
+          exec bash
+      - name: Build Installer
+        run: |
+          conda create -n constructor -c defaults constructor
           conda activate constructor
           constructor .
       - name: Create release

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build-conda-installer:
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
@@ -23,8 +26,8 @@ jobs:
           conda init bash
       - name: Build Installer
         run: |
-          conda install constructor
-          conda activate
+          conda create -n constructor -c defaults constructor
+          conda activate constructor
           conda info
           conda list
           constructor .

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -5,6 +5,7 @@ on:
       - 'v*.*.*'
 jobs:
   build-tar:
+    runs_on: ubuntu_latest
     steps:
       - users: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          installer-url: https://github.com/conda/conda-forge/miniforge/releases/lateset/download/Miniforge3-Linux-x86_64.sh
+          installer-url: https://github.com/conda-forge/miniforge/releases/tag/4.10.3-7/Miniforge3-4.10.3-7-Linux-x86_64.sh
       - name: build conda package
         run: conda build --quiet -c conda-forge conda-build
         timeout-minutes: 30

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-
+Ot2rec*.sh
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/conda-build/build.sh
+++ b/conda-build/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/conda-build/meta.yaml
+++ b/conda-build/meta.yaml
@@ -1,21 +1,41 @@
 package:
   name: ot2rec
-  version: "0.1.0"
+  version: "0.0.1"
 
 source:
   path: ..
 
- 
+build:
+  number: 0
+  entry_points:
+     - o2r.new = Ot2Rec.main:new_proj
+     - o2r.get_master = Ot2Rec.main:get_master_metadata
+     - o2r.mc.new=Ot2Rec.main:create_mc2_yaml
+     - o2r.mc.run=Ot2Rec.main:run_mc2
+     - o2r.ctffind.new=Ot2Rec.main:create_ctffind_yaml
+     - o2r.ctffind.run=Ot2Rec.main:run_ctffind
+     - o2r.align.new=Ot2Rec.main:create_align_yaml
+     - o2r.align.new_ext=Ot2Rec.main:create_align_yaml_stacked
+     - o2r.align.run=Ot2Rec.main:run_align
+     - o2r.align.run_ext=Ot2Rec.main:run_align_ext
+     - o2r.align.stats=Ot2Rec.main:get_align_stats
+     - o2r.recon.new=Ot2Rec.main:create_recon_yaml
+     - o2r.recon.run=Ot2Rec.main:run_recon
+     - o2r.cleanup=Ot2Rec.main:cleanup
+     - o2r.runall=Ot2Rec.main:run_all
+
 requirements:
   host:
     - python
     - setuptools
+    - pip
     
-  
   run: 
+    - python
     - tqdm
     - pandas
     - pyyaml
     - multiprocess
     - icecream
     - beautifultable
+    

--- a/conda-build/meta.yaml
+++ b/conda-build/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: ot2rec
+  version: "0.1.0"
+
+source:
+  path: ..
+
+ 
+requirements:
+  host:
+    - python
+    - setuptools
+    
+  
+  run: 
+    - tqdm
+    - pandas
+    - pyyaml
+    - multiprocess
+    - icecream
+    - beautifultable

--- a/conda-build/meta.yaml
+++ b/conda-build/meta.yaml
@@ -38,4 +38,8 @@ requirements:
     - multiprocess
     - icecream
     - beautifultable
-    
+
+about:
+  home: https://github.com/RosalindFranklinInstitute/Ot2Rec
+  summary: wrapper software for Electron Microscopy pipelines
+  license: Apache-2.0

--- a/conda-build/meta.yaml
+++ b/conda-build/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ot2rec
-  version: "0.0.1"
+  version: "0.1.0"
 
 source:
   path: ..

--- a/construct.yaml
+++ b/construct.yaml
@@ -3,7 +3,7 @@ version: 0.1.0
 company: Rosalind Franklin Institute
 channels:
   - https://conda.anaconda.org/conda-forge
-  - file:///home/laurashemilt/miniforge3/conda-bld/
+  - file:///usr/share/miniconda3/conda-bld/
 specs:
   - python 3.8.*
   - Ot2Rec 0.1.0

--- a/construct.yaml
+++ b/construct.yaml
@@ -1,0 +1,10 @@
+name: Ot2Rec
+version: 0.1.0
+company: Rosalind Franklin Institute
+channels:
+  - https://conda.anaconda.org/conda-forge
+  - file:///home/laurashemilt/miniforge3/conda-bld/
+specs:
+  - python 3.8.*
+  - Ot2Rec 0.1.0
+  - conda

--- a/construct.yaml
+++ b/construct.yaml
@@ -5,6 +5,6 @@ channels:
   - https://conda.anaconda.org/conda-forge
   - file:///usr/share/miniconda3/conda-bld/
 specs:
-  - python 3.8.*
+  - python 3.9.*
   - Ot2Rec 0.1.0
   - conda


### PR DESCRIPTION
This has a workflow which will make a release of Ot2rec when a commit is tagged and the tag is pushed.
The work flow will make a conda build of the package and release an installer. 
It will not affect any other workflows on push.
The idea that this is temporary to allow Ot2rec to be installed on the module share and will be replaced when we have the singularity installation.