### PR TITLE
Savu recon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+*.yaml

--- a/README.md
+++ b/README.md
@@ -403,8 +403,9 @@ o2r.align.run_ext demo
 
 
 ## 4. Reconstruction
-The final step of image processing is reconstruction, which is a continuation from the alignment process in IMOD.
+The final step of image processing is reconstruction, which is a continuation from the alignment process in IMOD. There are two options for reconstruction, IMOD and [Savu](https://savu.readthedocs.io/en/latest/). 
 
+## 4a. IMOD Reconstruction
 ### Creating configuration file
 To create the configuration file for reconstruction in IMOD, run the following command:
 ```
@@ -462,3 +463,60 @@ Parameters | Descriptions
 **`BatchRunTomo.reconstruction.thickness`** | Thickness (in pixels) for reconstruction
 **`BatchRunTomo.postprocessing.run_trimvol`** | If set to `true`, IMOD will run Trimvol on reconstruction
 **`BatchRunTomo.postprocessing.trimvol_reorient`** | Reorientation in Trimvol <br>(options: none \| flip \| rotate)
+
+### Running IMOD reconstruction
+
+Run the reconstruction with the following command:
+
+```
+o2r.recon.run demo
+```
+
+## 4b Savu Reconstruction
+
+### Setting up Savu reconstruction
+
+The ot2rec wrapper for Savu reads the aligned .mrc files, reconstructs the images using the `AstraReconGpu` [plugin](https://savu.readthedocs.io/en/latest/reference/plugin_documentation/plugins/reconstructions/astra_recons/astra_recon_gpu.html), and saves the reconstructed stack as a stack of tiff images.
+
+To create the configuration file to set up Savu reconstruction, run the following:
+
+```
+o2r.savu.new demo
+```
+
+which produces the file `demo_savurecon.yaml`:
+
+```
+System:
+    process_list: all
+    output_path: ./savurecon/
+    output_rootname: TS
+    output_suffix: ''
+Savu:
+    setup:
+        tilt_angles: .tlt
+        aligned_projections: '*_ali.mrc'
+        algorithm: CGLS_CUDA
+```
+
+### List of parameters
+Parameters | Descriptions 
+ --- | --- 
+**`System.process_list`** | (See above)
+**`System.output_path`** | (See above)
+**`System.output_rootname`** | (See above)
+**`System.output_suffix`** | (See above)
+ --- | ---
+**`Savu.setup.tilt_angles`** | Path to text files containing tilt angles for the aligned .mrc stacks, output by the alignment step. These files have the extension `.tlt` and this field is populated automatically if the alignment step has been run correctly.
+**`Savu.setup.aligned_projections`** | Path to `.mrc` files containing aligned tilt series. Populated automatically if alignment step has been run correctly.
+**`Savu.setup.algorithm`** | Reconstruction algorithm used by `AstraReconGpu`. Choices are ['FBP_CUDA', 'SIRT_CUDA', 'SART_CUDA', 'CGLS_CUDA', 'BP_CUDA', 'SIRT3D_CUDA', 'CGLS3D_CUDA']. Not using one of these options throws an error. See the [documentation](https://savu.readthedocs.io/en/latest/reference/plugin_documentation/plugins/reconstructions/astra_recons/astra_recon_gpu.html) for more information. The number of iterations `n_iterations` is set to 5 for `SIRT_CUDA`, `SART_CUDA`, or `CGLS_CUDA`. All other parameters are kept at default values.
+
+### Running Savu reconstruction
+
+To create Savu process lists and run them on the appropriate datasets, run:
+
+```
+o2r.savu.run demo
+```
+
+The resulting .tiff stacks can be viewed with any image processing software, e.g., [Fiji](https://imagej.net/software/fiji/).

--- a/README.md
+++ b/README.md
@@ -403,9 +403,8 @@ o2r.align.run_ext demo
 
 
 ## 4. Reconstruction
-The final step of image processing is reconstruction, which is a continuation from the alignment process in IMOD. There are two options for reconstruction, IMOD and [Savu](https://savu.readthedocs.io/en/latest/). 
+The final step of image processing is reconstruction, which is a continuation from the alignment process in IMOD.
 
-## 4a. IMOD Reconstruction
 ### Creating configuration file
 To create the configuration file for reconstruction in IMOD, run the following command:
 ```
@@ -463,60 +462,3 @@ Parameters | Descriptions
 **`BatchRunTomo.reconstruction.thickness`** | Thickness (in pixels) for reconstruction
 **`BatchRunTomo.postprocessing.run_trimvol`** | If set to `true`, IMOD will run Trimvol on reconstruction
 **`BatchRunTomo.postprocessing.trimvol_reorient`** | Reorientation in Trimvol <br>(options: none \| flip \| rotate)
-
-### Running IMOD reconstruction
-
-Run the reconstruction with the following command:
-
-```
-o2r.recon.run demo
-```
-
-## 4b Savu Reconstruction
-
-### Setting up Savu reconstruction
-
-The ot2rec wrapper for Savu reads the aligned .mrc files, reconstructs the images using the `AstraReconGpu` [plugin](https://savu.readthedocs.io/en/latest/reference/plugin_documentation/plugins/reconstructions/astra_recons/astra_recon_gpu.html), and saves the reconstructed stack as a stack of tiff images.
-
-To create the configuration file to set up Savu reconstruction, run the following:
-
-```
-o2r.savu.new demo
-```
-
-which produces the file `demo_savurecon.yaml`:
-
-```
-System:
-    process_list: all
-    output_path: ./savurecon/
-    output_rootname: TS
-    output_suffix: ''
-Savu:
-    setup:
-        tilt_angles: .tlt
-        aligned_projections: '*_ali.mrc'
-        algorithm: CGLS_CUDA
-```
-
-### List of parameters
-Parameters | Descriptions 
- --- | --- 
-**`System.process_list`** | (See above)
-**`System.output_path`** | (See above)
-**`System.output_rootname`** | (See above)
-**`System.output_suffix`** | (See above)
- --- | ---
-**`Savu.setup.tilt_angles`** | Path to text files containing tilt angles for the aligned .mrc stacks, output by the alignment step. These files have the extension `.tlt` and this field is populated automatically if the alignment step has been run correctly.
-**`Savu.setup.aligned_projections`** | Path to `.mrc` files containing aligned tilt series. Populated automatically if alignment step has been run correctly.
-**`Savu.setup.algorithm`** | Reconstruction algorithm used by `AstraReconGpu`. Choices are ['FBP_CUDA', 'SIRT_CUDA', 'SART_CUDA', 'CGLS_CUDA', 'BP_CUDA', 'SIRT3D_CUDA', 'CGLS3D_CUDA']. Not using one of these options throws an error. See the [documentation](https://savu.readthedocs.io/en/latest/reference/plugin_documentation/plugins/reconstructions/astra_recons/astra_recon_gpu.html) for more information. The number of iterations `n_iterations` is set to 5 for `SIRT_CUDA`, `SART_CUDA`, or `CGLS_CUDA`. All other parameters are kept at default values.
-
-### Running Savu reconstruction
-
-To create Savu process lists and run them on the appropriate datasets, run:
-
-```
-o2r.savu.run demo
-```
-
-The resulting .tiff stacks can be viewed with any image processing software, e.g., [Fiji](https://imagej.net/software/fiji/).

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
             "o2r.recon.run=Ot2Rec.main:run_recon",
 
             "o2r.savu.new=Ot2Rec.main:create_savurecon_yaml",
-            "o2r.savu.run=Ot2Rec.main:run_savurecon"
+            "o2r.savu.run=Ot2Rec.main:run_savurecon",
 
             "o2r.cleanup=Ot2Rec.main:cleanup",
             "o2r.runall=Ot2Rec.main:run_all",

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ setup(
             "o2r.recon.new=Ot2Rec.main:create_recon_yaml",
             "o2r.recon.run=Ot2Rec.main:run_recon",
 
+            "o2r.savu.new=Ot2Rec.main:create_savurecon_yaml",
+            "o2r.savu.run=Ot2Rec.main:run_savurecon"
+
             "o2r.cleanup=Ot2Rec.main:cleanup",
             "o2r.runall=Ot2Rec.main:run_all",
         ]

--- a/src/Ot2Rec/main.py
+++ b/src/Ot2Rec/main.py
@@ -31,6 +31,7 @@ from . import logger as logMod
 from . import ctffind as ctfMod
 from . import align as alignMod
 from . import recon as reconMod
+from . import savurecon as savuMod
 
 
 def get_proj_name():
@@ -658,6 +659,84 @@ def run_recon():
     # Run IMOD
     if not recon_obj.no_processes:
         recon_obj.recon_stack()
+
+
+def update_savurecon_yaml():
+    """
+    Subroutine to update yaml file for savu reconstruction
+    """
+
+    project_name = get_proj_name()
+    
+    # Check if savurecon, align, and align_mdout yaml files exist
+    savurecon_yaml_name = project_name + '_savurecon.yaml'
+    align_yaml_name = project_name + '_align.yaml'
+    align_md_name = project_name + '_align_mdout.yaml'
+    if not os.path.isfile(savurecon_yaml_name):
+        raise IOError("Error in Ot2Rec.main.update_savurecon_yaml: reconstruction config file not found.")
+    if not os.path.isfile(align_yaml_name):
+        raise IOError("Error in Ot2Rec.main.update_savurecon_yaml: align.yaml file not found")
+    if not os.path.isfile(align_md_name):
+        raise IOError("Error in Ot2Rec.main.update_savurecon_yaml: alignment mdout file not found.")
+
+    # Read in alignment metadata (as Pandas dataframe)
+    with open(align_md_name, 'r') as f:
+        align_md_df = pd.DataFrame(yaml.load(f, Loader=yaml.FullLoader))
+        align_md_ts = align_md_df['ts']
+        align_output = align_md_df['align_output']
+
+    savurecon_params = prmMod.read_yaml(project_name=project_name,
+                                    filename=savurecon_yaml_name)
+    align_params = prmMod.read_yaml(project_name=project_name,
+                                  filename=align_yaml_name)
+
+    # Get tilt angle files
+    align_tilt_files = []
+    for f in align_md_df['stack_output']:
+        align_tilt_files.append(f.replace('.st', '.tlt'))
+
+    # Update savurecon yaml
+    savurecon_params.params['System']['process_list'] = align_md_ts.sort_values(ascending=True).unique().tolist()
+    savurecon_params.params['System']['output_rootname'] = align_params.params['System']['output_rootname']
+    savurecon_params.params['System']['output_suffix'] = align_params.params['System']['output_suffix']
+    savurecon_params.params['Savu']['setup']['tilt_angles'] = align_tilt_files
+    savurecon_params.params['Savu']['setup']['aligned_projections'] = align_output.sort_values(ascending=True).unique().tolist()
+    
+    with open(savurecon_yaml_name, 'w') as f:
+        yaml.dump(savurecon_params.params, f, indent=4, sort_keys=False) 
+
+
+def create_savurecon_yaml():
+    """
+    Creates yaml for savu reconstruction
+    """
+    project_name = get_proj_name()
+
+    # Create savurecon yaml file and automatically update it
+    prmMod.new_savurecon_yaml(project_name)
+    update_savurecon_yaml()
+
+
+def run_savurecon():
+    project_name = get_proj_name()
+    
+    # Check if prerequisite files exist
+    savurecon_yaml = project_name + '_savurecon.yaml'
+
+    # Read in config and metadata
+    savurecon_params = prmMod.read_yaml(project_name=project_name,
+                                        filename=savurecon_yaml)
+
+    # Create Logger object
+    # logger = logMod.Logger()
+    
+    # Create SavuRecon object
+    savurecon_obj = savuMod.SavuRecon(project_name=project_name,
+                                  params_in=savurecon_params,
+                                 )
+
+    # Run Savu
+    savurecon_obj.run_savu_all()
 
 
 def cleanup():

--- a/src/Ot2Rec/main.py
+++ b/src/Ot2Rec/main.py
@@ -728,11 +728,12 @@ def run_savurecon():
                                         filename=savurecon_yaml)
 
     # Create Logger object
-    # logger = logMod.Logger()
+    logger = logMod.Logger()
     
     # Create SavuRecon object
     savurecon_obj = savuMod.SavuRecon(project_name=project_name,
                                   params_in=savurecon_params,
+                                  logger_in=logger,
                                  )
 
     # Run Savu

--- a/src/Ot2Rec/params.py
+++ b/src/Ot2Rec/params.py
@@ -257,6 +257,37 @@ def new_recon_yaml(project_name: str):
     with open(recon_yaml_name, 'w') as f:
         yaml.dump(recon_yaml_dict, f, indent=4, sort_keys=False)
 
+
+def new_savurecon_yaml(project_name: str):
+    """
+    Subroutine to create yaml file for savurecon (continuing from aligned stacks to full reconstruction)
+
+    ARGS:
+    project_name :: Name of current project
+    """
+
+    savurecon_yaml_name = project_name + '_savurecon.yaml'
+
+    savurecon_yaml_dict = {
+        'System' : {
+            'process_list' : 'all',
+            'output_path' : './savurecon/',
+            'output_rootname' : 'TS',
+            'output_suffix' : '',
+        },
+        
+        'Savu': {
+            'setup': {
+                'tilt_angles': '.tlt',
+                'aligned_projections': '*_ali.mrc',
+                'algorithm': 'CGLS_CUDA',
+            }
+        }
+    }
+                
+    with open(savurecon_yaml_name, 'w') as f:
+        yaml.dump(savurecon_yaml_dict, f, indent=4, sort_keys=False)
+
         
 def read_yaml(project_name: str,
               filename: str):

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -1,0 +1,182 @@
+# Copyright 2021 Rosalind Franklin Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+import yaml
+import os
+import subprocess 
+
+
+class SavuRecon:
+    """
+    Class encapsulating a SavuRecon object
+    """
+
+
+    def __init__(self,
+                 project_name,
+                 params_in,
+    ):
+        """
+        Initialising a SavuRecon object
+
+        ARGS:
+        project_name (str) :: name of current project
+        params_in (Params) :: parameters for stack creation
+        """
+
+        self.proj_name = project_name
+
+        self.pObj = params_in
+        self.params = self.pObj.params
+
+        self.md_out = dict()
+
+        self._get_internal_metadata()
+
+
+    def _get_internal_metadata(self):
+        """
+        Method to prepare internal metadata for processing and checking
+        """
+        self.basis_folder = self.params['System']['output_path']
+        if self.basis_folder.endswith('/'):
+            self.basis_folder = self.basis_folder[:-1]
+        
+        self.rootname = self.params['System']['output_rootname']
+        if self.rootname.endswith('_'):
+            self.rootname = self.rootname[:-1]
+        
+        self.suffix = self.params['System']['output_suffix']
+        if self.suffix.endswith('_'):
+            self.suffix = self.suffix[:-1]
+        
+        # Create the folders and dictionary for future reference
+        self._path_dict = dict()
+        for curr_ts in self.params['System']['process_list']:
+            subfolder = f"{self.basis_folder}/{self.rootname}_{curr_ts:02d}{self.suffix}"
+            os.makedirs(subfolder, exist_ok=True)
+            # self._path_dict[curr_ts] = subfolder
+            if "savu_output_dir" not in list(self.md_out.keys()):
+                self.md_out["savu_output_dir"] = {}
+            self.md_out["savu_output_dir"][curr_ts] = subfolder
+        
+
+    def _get_savuconfig_recon_command(self, i):
+        """
+        Method to get command to set up Savu process list
+
+        ARGS:
+        i (int): The i-th tilt series to process
+        """
+        
+        curr_ts = self.params['System']['process_list'][i]
+        # Get tilt angles .tlt file for this iteration
+        ts_name = os.path.splitext(
+                    os.path.basename(
+                        self.params['Savu']['setup']['tilt_angles'][i]))[0]
+
+        # Get reconstruction algorithm and check that it is a valid choice
+        algo = self.params['Savu']['setup']['algorithm']
+        algo_choices = ["FBP_CUDA", "SIRT_CUDA", "SART_CUDA", "CGLS_CUDA", "BP_CUDA", "SIRT3D_CUDA", "CGLS3D_CUDA"]
+        if algo not in algo_choices:
+            raise ValueError(
+                "Algorithm not supported. Please amend algorithm in savurecon.yaml to one of {}".format(algo_choices)
+                )
+
+        cmd = ['add MrcLoader\n',
+                'mod 1.2 {}\n'.format(self.params['Savu']['setup']['tilt_angles'][i]),
+                'add AstraReconGpu\n',
+                'mod 2.2 {}\n'.format(algo),
+                'add TiffSaver\n',
+                'mod 3.1 VOLUME_YZ\n',
+                'save {}_{}.nxs\n'.format(ts_name, algo),
+                'y\n',
+                'exit\n',
+                'y\n'
+                ]
+        if self.params['Savu']['setup']['algorithm'] != "FBP_CUDA":
+            cmd.insert(4, "mod 2.2 5\n")
+        
+        # Add location of .nxs file to metadata
+        if "savu_process_lists" not in list(self.md_out.keys()):
+            self.md_out['savu_process_lists'] = {}
+        self.md_out['savu_process_lists'][curr_ts] = '{}_{}.nxs'.format(ts_name, algo)
+        
+        return cmd
+    
+
+    def savurecon_stack(self, i):
+        """
+        Method to generate savu_config process list and run savu for the i-th ts
+        """
+        curr_ts = self.params['System']['process_list'][i]
+        cmd = self._get_savuconfig_recon_command(i)
+        savu_config = subprocess.Popen('savu_config',
+                                     stdin=subprocess.PIPE,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.STDOUT,
+                                     encoding='ascii',
+                                     )
+        
+        # Feed commands to savu_config to make process list
+        for command in cmd:
+            savu_config.stdin.write(command)
+        print(savu_config.communicate()[0])
+
+        # Run savu
+        savu_run = subprocess.run(['savu',
+                                   self.params['Savu']['setup']['aligned_projections'][i],
+                                   self.md_out['savu_process_lists'][curr_ts],
+                                   self.md_out['savu_output_dir'][curr_ts]],
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.STDOUT,
+                                   encoding='ascii',
+                                   )
+
+
+    def dummy_runner(self, i):
+        """
+        Temp method to test locally that commands are created correctly
+        """
+        curr_ts = self.params['System']['process_list'][i]
+        cmd = self._get_savuconfig_recon_command(i)
+        print(cmd)
+        print(['savu',
+                self.params['Savu']['setup']['aligned_projections'][i],
+                self.md_out['savu_process_lists'][curr_ts],
+                self.md_out['savu_output_dir'][curr_ts]],
+        )
+    
+
+    def run_savu_all(self):
+        """
+        Method to run savurecon_stack for all ts in process list
+        """
+        for i, curr_ts in enumerate(self.params['System']['process_list']):
+            self.savurecon_stack(i)
+            # self.dummy_runner(i)
+        print("Savu reconstruction complete for {}_{}".format(self.proj_name, curr_ts))
+        self.export_metadata()
+
+    
+    def export_metadata(self):
+        """
+        Method to export metadata as yaml
+        """
+
+        yaml_file = self.proj_name + "_savurecon_mdout.yaml"
+
+        with open(yaml_file, 'w') as f:
+            yaml.dump(self.md_out, f, indent=4, sort_keys=False)

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -112,7 +112,7 @@ class SavuRecon:
                 'exit\n',
                 'y\n'
                 ]
-        if self.params['Savu']['setup']['algorithm'] != "FBP_CUDA":
+        if algo=="SIRT_CUDA" or algo=="SART_CUDA" or algo=="CGLS_CUDA":
             cmd.insert(4, "mod 2.2 5\n")
         
         # Add location of .nxs file to metadata

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -95,7 +95,7 @@ class SavuRecon:
                 "Algorithm not supported. Please amend algorithm in savurecon.yaml to one of {}".format(algo_choices)
                 )
         
-        subfolder = self.md_out["savu_output_dir"][curr_ts]
+        subfolder = os.path.abspath(self.md_out["savu_output_dir"][curr_ts])
 
         cmd = ['add MrcLoader\n',
                 'mod 1.2 {}\n'.format(self.params['Savu']['setup']['tilt_angles'][i]),

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -94,6 +94,8 @@ class SavuRecon:
             raise ValueError(
                 "Algorithm not supported. Please amend algorithm in savurecon.yaml to one of {}".format(algo_choices)
                 )
+        
+        subfolder = self.md_out["savu_output_dir"][curr_ts]
 
         cmd = ['add MrcLoader\n',
                 'mod 1.2 {}\n'.format(self.params['Savu']['setup']['tilt_angles'][i]),
@@ -101,7 +103,7 @@ class SavuRecon:
                 'mod 2.2 {}\n'.format(algo),
                 'add TiffSaver\n',
                 'mod 3.1 VOLUME_YZ\n',
-                'save {}_{}.nxs\n'.format(ts_name, algo),
+                'save {}/{}_{}.nxs\n'.format(subfolder, ts_name, algo),
                 'y\n',
                 'exit\n',
                 'y\n'
@@ -112,7 +114,7 @@ class SavuRecon:
         # Add location of .nxs file to metadata
         if "savu_process_lists" not in list(self.md_out.keys()):
             self.md_out['savu_process_lists'] = {}
-        self.md_out['savu_process_lists'][curr_ts] = '{}_{}.nxs'.format(ts_name, algo)
+        self.md_out['savu_process_lists'][curr_ts] = '{}/{}_{}.nxs'.format(subfolder, ts_name, algo)
         
         return cmd
     
@@ -133,7 +135,7 @@ class SavuRecon:
         # Feed commands to savu_config to make process list
         for command in cmd:
             savu_config.stdin.write(command)
-        print(savu_config.communicate()[0])
+        # print(savu_config.communicate()[0])
 
         # Run savu
         savu_run = subprocess.run(['savu',
@@ -144,6 +146,7 @@ class SavuRecon:
                                    stderr=subprocess.STDOUT,
                                    encoding='ascii',
                                    )
+        # print(savu_run.stdout)
 
 
     def dummy_runner(self, i):

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -15,7 +15,7 @@
 
 import yaml
 import os
-import subprocess 
+import subprocess
 
 
 class SavuRecon:
@@ -27,6 +27,7 @@ class SavuRecon:
     def __init__(self,
                  project_name,
                  params_in,
+                 logger_in,
     ):
         """
         Initialising a SavuRecon object
@@ -34,12 +35,15 @@ class SavuRecon:
         ARGS:
         project_name (str) :: name of current project
         params_in (Params) :: parameters for stack creation
+        logger_in (Logger) :: logger object to keep record of progress and errors
         """
 
         self.proj_name = project_name
 
         self.pObj = params_in
         self.params = self.pObj.params
+
+        self.logObj = logger_in
 
         self.md_out = dict()
 

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -174,7 +174,7 @@ class SavuRecon:
         for i, curr_ts in enumerate(self.params['System']['process_list']):
             self.savurecon_stack(i)
             # self.dummy_runner(i)
-        print("Savu reconstruction complete for {}_{}".format(self.proj_name, curr_ts))
+            print("Savu reconstruction complete for {}_{}".format(self.proj_name, curr_ts))
         self.export_metadata()
 
     


### PR DESCRIPTION
Adds an alternative reconstruction wrapper around [Savu](https://savu.readthedocs.io/en/latest/index.html), which takes the aligned `.mrc` files, reconstructs with `AstraReconGpu`, and outputs as a stack of `.tiff` images.

`o2r.savu.new` creates the .yaml config file to set up Savu reconstruction, where the details are populated from previous steps, the only parameter the user would have to change manually is the algorithm. An error is raised by `o2r.savu.run` if the algorithm type is not supported, which will show the choices allowed (`['FBP_CUDA', 'SIRT_CUDA', 'SART_CUDA', 'CGLS_CUDA', 'BP_CUDA', 'SIRT3D_CUDA', 'CGLS3D_CUDA']`)

**This version of o2r requires Savu to be installed on the system** 
