### PR TITLE
Feature issue12: set centre of rotation in `savu` reconstruction

### DIFF
--- a/src/Ot2Rec/main.py
+++ b/src/Ot2Rec/main.py
@@ -715,9 +715,16 @@ def update_savurecon_yaml():
     savurecon_params.params['System']['output_suffix'] = align_params.params['System']['output_suffix']
     savurecon_params.params['Savu']['setup']['tilt_angles'] = align_tilt_files
     savurecon_params.params['Savu']['setup']['aligned_projections'] = align_output.sort_values(ascending=True).unique().tolist()
+
+    # Change centre of rotation to centre of image by default
+    centre_of_rotation = []
+    for image in savurecon_params.params['Savu']['setup']['aligned_projections']:
+        mrc = mrcfile.open(image)
+        centre_of_rotation.append(float(mrc.header["ny"]/2)) # ydim/2
+    savurecon_params.params['Savu']['setup']['centre_of_rotation'] = centre_of_rotation
     
     with open(savurecon_yaml_name, 'w') as f:
-        yaml.dump(savurecon_params.params, f, indent=4, sort_keys=False) 
+        yaml.dump(savurecon_params.params, f, indent=4, sort_keys=False)
 
 
 def create_savurecon_yaml():

--- a/src/Ot2Rec/params.py
+++ b/src/Ot2Rec/params.py
@@ -281,6 +281,7 @@ def new_savurecon_yaml(project_name: str):
                 'tilt_angles': '.tlt',
                 'aligned_projections': '*_ali.mrc',
                 'algorithm': 'CGLS_CUDA',
+                'centre_of_rotation': '0.0',
             }
         }
     }

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -104,6 +104,7 @@ class SavuRecon:
         cmd = ['add MrcLoader\n',
                 'mod 1.2 {}\n'.format(self.params['Savu']['setup']['tilt_angles'][i]),
                 'add AstraReconGpu\n',
+                'mod 2.1 {}\n'.format(self.params['Savu']['setup']['centre_of_rotation'][i]),
                 'mod 2.2 {}\n'.format(algo),
                 'add TiffSaver\n',
                 'mod 3.1 VOLUME_YZ\n',


### PR DESCRIPTION
closes #12 by adding option to set centre of rotation in savu.

Centre of rotation is set by default to the centre of the image (i.e., 0.5 * the y-dim of the aligned image from the mrc header of the aligned projection image). This is put into the savurecon.yaml file which can be edited manually. 

Should also work on tilt series of different sizes as each centre of rotation is calculated per tilt series rather than using one value for the entire project.