### PR TITLE
Allows centre of rotation to be a single line (Issue#12)

### DIFF
--- a/src/Ot2Rec/main.py
+++ b/src/Ot2Rec/main.py
@@ -717,11 +717,11 @@ def update_savurecon_yaml():
     savurecon_params.params['Savu']['setup']['aligned_projections'] = align_output.sort_values(ascending=True).unique().tolist()
 
     # Change centre of rotation to centre of image by default
-    centre_of_rotation = []
-    for image in savurecon_params.params['Savu']['setup']['aligned_projections']:
-        mrc = mrcfile.open(image)
-        centre_of_rotation.append(float(mrc.header["ny"]/2)) # ydim/2
-    savurecon_params.params['Savu']['setup']['centre_of_rotation'] = centre_of_rotation
+    # centre_of_rotation = []
+    # for image in savurecon_params.params['Savu']['setup']['aligned_projections']:
+    #     mrc = mrcfile.open(image)
+    #     centre_of_rotation.append(float(mrc.header["ny"]/2)) # ydim/2
+    # savurecon_params.params['Savu']['setup']['centre_of_rotation'] = centre_of_rotation
     
     with open(savurecon_yaml_name, 'w') as f:
         yaml.dump(savurecon_params.params, f, indent=4, sort_keys=False)

--- a/src/Ot2Rec/params.py
+++ b/src/Ot2Rec/params.py
@@ -281,7 +281,7 @@ def new_savurecon_yaml(project_name: str):
                 'tilt_angles': '.tlt',
                 'aligned_projections': '*_ali.mrc',
                 'algorithm': 'CGLS_CUDA',
-                'centre_of_rotation': '0.0',
+                'centre_of_rotation': 'autocenter',
             }
         }
     }

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -16,6 +16,7 @@
 import yaml
 import os
 import subprocess
+import mrcfile
 
 
 class SavuRecon:
@@ -99,12 +100,24 @@ class SavuRecon:
                 "Algorithm not supported. Please amend algorithm in savurecon.yaml to one of {}".format(algo_choices)
                 )
         
-        subfolder = os.path.abspath(self.md_out["savu_output_dir"][curr_ts])
+        # Get centre of rotation
+        # Set centre of rotation to centre if centre_of_rotation is autocenter
+        if self.params['Savu']['setup']['centre_of_rotation'] == 'autocenter':
+            mrc = mrcfile.open(self.params['Savu']['setup']['aligned_projections'][i])
+            cor = float(mrc.header["ny"]/2) # ydim/2
 
+        # Else if the centre of rotation is a single value to be used for all ts:
+        else:
+            try:
+                cor = float(self.params['Savu']['setup']['centre_of_rotation'])
+            except:
+                raise ValueError('Centre of rotation must be `autocenter` or a float')
+
+        subfolder = os.path.abspath(self.md_out["savu_output_dir"][curr_ts])
         cmd = ['add MrcLoader\n',
                 'mod 1.2 {}\n'.format(self.params['Savu']['setup']['tilt_angles'][i]),
                 'add AstraReconGpu\n',
-                'mod 2.1 {}\n'.format(self.params['Savu']['setup']['centre_of_rotation'][i]),
+                'mod 2.1 {}\n'.format(cor),
                 'mod 2.2 {}\n'.format(algo),
                 'add TiffSaver\n',
                 'mod 3.1 VOLUME_YZ\n',


### PR DESCRIPTION
If the centre of rotation is set to 'autocenter' in the `savurecon.yaml`
file, then use the centre of the stack as the centre of rotation.

If the centre of rotation is set to a float, use this value for all ts.

If the centre of rotation is not a float or 'autocenter' then raise
ValueError.