### PR TITLE
Output Savu reconstructions as mrc

### DIFF
--- a/src/Ot2Rec/main.py
+++ b/src/Ot2Rec/main.py
@@ -966,68 +966,7 @@ def run_recon():
     if not recon_obj.no_processes:
         recon_obj.recon_stack()
 
-
-def update_savurecon_yaml():
-    """
-    Subroutine to update yaml file for savu reconstruction
-    """
-
-    project_name = get_proj_name()
-
-    # Check if savurecon, align, and align_mdout yaml files exist
-    savurecon_yaml_name = project_name + '_savurecon.yaml'
-    align_yaml_name = project_name + '_align.yaml'
-    align_md_name = project_name + '_align_mdout.yaml'
-    if not os.path.isfile(savurecon_yaml_name):
-        raise IOError("Error in Ot2Rec.main.update_savurecon_yaml: reconstruction config file not found.")
-    if not os.path.isfile(align_yaml_name):
-        raise IOError("Error in Ot2Rec.main.update_savurecon_yaml: align.yaml file not found")
-    if not os.path.isfile(align_md_name):
-        raise IOError("Error in Ot2Rec.main.update_savurecon_yaml: alignment mdout file not found.")
-
-    # Read in alignment metadata (as Pandas dataframe)
-    with open(align_md_name, 'r') as f:
-        align_md_df = pd.DataFrame(yaml.load(f, Loader=yaml.FullLoader))
-        align_md_ts = align_md_df['ts']
-        align_output = align_md_df['align_output']
-
-    savurecon_params = prmMod.read_yaml(project_name=project_name,
-                                    filename=savurecon_yaml_name)
-    align_params = prmMod.read_yaml(project_name=project_name,
-                                  filename=align_yaml_name)
-
-    # Get tilt angle files
-    align_tilt_files = []
-    for f in align_md_df['stack_output']:
-        align_tilt_files.append(f.replace('.st', '.tlt'))
-
-    # Update savurecon yaml
-    savurecon_params.params['System']['process_list'] = align_md_ts.sort_values(ascending=True).unique().tolist()
-    savurecon_params.params['System']['output_rootname'] = align_params.params['System']['output_rootname']
-    savurecon_params.params['System']['output_suffix'] = align_params.params['System']['output_suffix']
-    savurecon_params.params['Savu']['setup']['tilt_angles'] = align_tilt_files
-    savurecon_params.params['Savu']['setup']['aligned_projections'] = align_output.sort_values(ascending=True).unique().tolist()
-
-
-    # Change centre of rotation to centre of image by default
-    centre_of_rotation = []
-    for image in savurecon_params.params['Savu']['setup']['aligned_projections']:
-        mrc = mrcfile.open(image)
-        centre_of_rotation.append(float(mrc.header["ny"]/2)) # ydim/2
-    savurecon_params.params['Savu']['setup']['centre_of_rotation'] = centre_of_rotation
-
-    
-def create_savurecon_yaml():
-    """
-    Creates yaml for savu reconstruction
-    """
-    project_name = get_proj_name()
-
-    # Create savurecon yaml file and automatically update it
-    prmMod.new_savurecon_yaml(project_name)
-    update_savurecon_yaml()
-
-
+ 
 def run_savurecon():
     project_name = get_proj_name()
 

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -106,7 +106,7 @@ class SavuRecon:
                 'add AstraReconGpu\n',
                 'mod 2.1 {}\n'.format(self.params['Savu']['setup']['centre_of_rotation'][i]),
                 'mod 2.2 {}\n'.format(algo),
-                'add TiffSaver\n',
+                'add MrcSaver\n',
                 'mod 3.1 VOLUME_YZ\n',
                 'save {}/{}_{}.nxs\n'.format(subfolder, ts_name, algo),
                 'y\n',


### PR DESCRIPTION
Replaces the old `TiffSaver` plugin in Savu with [`MrcSaver`](https://github.com/DiamondLightSource/Savu/pull/883).

For the `MrcSaver` plugin to work, Savu must be installed straight from the git repo: use 1b from the [installation guide](https://savu.readthedocs.io/en/latest/howto/install/savu_lite.html).

Also deprecates the old `create_savurecon_yaml` and `update_savurecon_yaml` which have now been updated to use the `ArgParse` system.