### PR TITLE
Splitting of stack creation and alignment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,12 @@ setup(
             "o2r.ctfsim.run=Ot2Rec.main:run_ctfsim",
 
             "o2r.align.new=Ot2Rec.main:create_align_yaml",
-            "o2r.align.new_ext=Ot2Rec.main:create_align_yaml_stacked",
+            "o2r.align.stacks=Ot2Rec.main:create_stacks",
             "o2r.align.run=Ot2Rec.main:run_align",
-            "o2r.align.run_ext=Ot2Rec.main:run_align_ext",
             "o2r.align.stats=Ot2Rec.main:get_align_stats",
+
+            "o2r.align.new_ext=Ot2Rec.main:create_align_yaml_stacked",
+            "o2r.align.run_ext=Ot2Rec.main:run_align_ext",
 
             "o2r.recon.new=Ot2Rec.main:create_recon_yaml",
             "o2r.recon.run=Ot2Rec.main:run_recon",

--- a/src/Ot2Rec/align.py
+++ b/src/Ot2Rec/align.py
@@ -249,6 +249,8 @@ class Align:
                                  f'on stack{curr_ts}.')
             else:
                 self.stdout = run_newstack.stdout
+                self.update_align_metadata(ext=False)
+                self.export_metadata()
 
             
     """

--- a/src/Ot2Rec/main.py
+++ b/src/Ot2Rec/main.py
@@ -683,7 +683,14 @@ def create_align_yaml_stacked():
     update_align_yaml_stacked()
 
 
-def run_align():
+def create_stacks():
+    """
+    Method to only create stacks using IMOD but omit alignment
+    """
+    run_align(full_align=False)
+
+
+def run_align(full_align=True):
     """
     Method to run IMOD newstack / alignment
     """
@@ -722,7 +729,8 @@ def run_align():
         align_obj.create_stack_folders()
         align_obj.create_rawtlt()
         align_obj.create_stack()
-        align_obj.align_stack()
+        if full_align:
+            align_obj.align_stack()
 
 
 def run_align_ext():

--- a/src/Ot2Rec/main.py
+++ b/src/Ot2Rec/main.py
@@ -685,7 +685,8 @@ def create_align_yaml_stacked():
 
 def create_stacks():
     """
-    Method to only create stacks using IMOD but omit alignment
+    Method to only create stacks using IMOD but omit alignment.
+    Separated from the rest of alignment so users can continue processing with other program.
     """
     run_align(full_align=False)
 


### PR DESCRIPTION
## Overview
- Changes in codes (primarily main and align) to split IMOD processes of stack creation and alignment
- Added new entry point in setup (`o2r.align.stacks`) to call function

## New usage caveats
- Still need to create input YAML using `o2r.align.new`
- `o2r.align.stacks` only creates .st files --- **No metadata updates** .
- If user wants to carry on with IMOD alignment, use `o2r.align.run_ext` as if stacks are from external sources. **Metadata updated here for downstream O2R processes**
- Old command `o2r.align.run` still works, but it is now a 2-in-1 command --- `o2r.align.stacks` + `o2r.align.run_ext`