### PR TITLE
Bugfix Aretomo kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ dmypy.json
 .pyre/
 
 *.yaml
+*.sh
+demo/processing/*

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
 
             "o2r.ctffind.new=Ot2Rec.ctffind:create_yaml",
             "o2r.ctffind.run=Ot2Rec.ctffind:run",
-            
+
             "o2r.ctfsim.run=Ot2Rec.ctfsim:run",
 
             "o2r.imod.align.new=Ot2Rec.align:create_yaml",
@@ -58,7 +58,7 @@ setup(
             "o2r.imod.align.run_ext=Ot2Rec.align:imod_align_ext",
 
             "o2r.imod.align.stats=Ot2Rec.align:get_align_stats",
-            
+
             "o2r.imod.recon.new=Ot2Rec.recon:create_yaml",
             "o2r.imod.recon.run=Ot2Rec.recon:run",
 

--- a/src/Ot2Rec/aretomo.py
+++ b/src/Ot2Rec/aretomo.py
@@ -153,10 +153,11 @@ class AreTomo:
             cmd = recon_cmd
 
         # Add extra kwargs
-        kwargs = self.params["AreTomo_kwargs"].keys()
-        for kwarg in kwargs:
-            cmd.append(kwarg)
-            cmd.append(self.params["AreTomo_kwargs"][kwarg])
+        if len(self.params["AreTomo_kwargs"]) > 0:
+            kwargs = self.params["AreTomo_kwargs"].keys()
+            for kwarg in kwargs:
+                cmd.append(kwarg)
+                cmd.append(self.params["AreTomo_kwargs"][kwarg])
 
         # Add AreTomo command and out_mrc to md_out
         if "aretomo_cmd" not in list(self.md_out.keys()):


### PR DESCRIPTION
Fixes error in `o2r.aretomo.run` when no extra kwargs are given.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an if loop so no extra arguments are added to the AreTomo command if `params["AreTomo_kwargs"]` is empty.

## Related Issue
Fixes #45 

## How Has This Been Tested?
In tests/test_aretomo.py: `test_aretomo_extra_kwargs` passes.
Manual testing in the terminal:
(using the demo dataset)
```
o2r.aretomo.new TS 0 90
o2r.aretomo.run TS 0
o2r.aretomo.new TS 1 90 --volz 200
o2r.aretomo.run TS 1
```
