### PR TITLE
Bugfix issue47

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Execute tests within container
         run: |
           docker run --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
-            xvfb-run python -m pytest --cov=/usr/local/Ot2Rec/src /usr/local/Ot2Rec/tests/ \
+            python -m pytest --cov=/usr/local/Ot2Rec/src /usr/local/Ot2Rec/tests/ \
             --cov-report xml:coverage.xml --cov-report term-missing
 
       - name: Submit coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Execute tests within container
         run: |
-          docker run --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
+          docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
                      python -m pytest --cov=/usr/local/Ot2Rec/src /usr/local/Ot2Rec/tests/ \
                                       --cov-report xml:coverage.xml --cov-report term-missing
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,10 @@ jobs:
 
       - name: Execute tests within container
         run: |
-          docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw -t --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
-                     python -m pytest --cov=/usr/local/Ot2Rec/src /usr/local/Ot2Rec/tests/ \
-                                      --cov-report xml:coverage.xml --cov-report term-missing
+          docker run --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
+            -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY \
+            python -m pytest --cov=/usr/local/Ot2Rec/src /usr/local/Ot2Rec/tests/ \
+            --cov-report xml:coverage.xml --cov-report term-missing
 
       - name: Submit coverage to Codecov
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Execute tests within container
         run: |
-          docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw -it --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
+          docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw -T --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
                      python -m pytest --cov=/usr/local/Ot2Rec/src /usr/local/Ot2Rec/tests/ \
                                       --cov-report xml:coverage.xml --cov-report term-missing
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Execute tests within container
         run: |
-          docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
+          docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw -it --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
                      python -m pytest --cov=/usr/local/Ot2Rec/src /usr/local/Ot2Rec/tests/ \
                                       --cov-report xml:coverage.xml --cov-report term-missing
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,7 @@ jobs:
       - name: Execute tests within container
         run: |
           docker run --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
-            -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY \
-            python -m pytest --cov=/usr/local/Ot2Rec/src /usr/local/Ot2Rec/tests/ \
+            xvfb-run python -m pytest --cov=/usr/local/Ot2Rec/src /usr/local/Ot2Rec/tests/ \
             --cov-report xml:coverage.xml --cov-report term-missing
 
       - name: Submit coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Execute tests within container
         run: |
-          docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw -T --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
+          docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw -t --rm -v $(pwd):/tmp/repo/ -w /tmp/repo/ $DOCKER_REPO_NAME \
                      python -m pytest --cov=/usr/local/Ot2Rec/src /usr/local/Ot2Rec/tests/ \
                                       --cov-report xml:coverage.xml --cov-report term-missing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,12 @@
 
 FROM nvidia/cuda:11.4.0-base-ubuntu20.04
 
-# Following https://github.com/jozo/docker-pyqt5/blob/master/default/Dockerfile
-ENV LIBGL_ALWAYS_INDIRECT=1
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install packages and register python3 as python
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update -y && apt-get install -y dialog apt-utils && \
-    apt-get install -y build-essential git wget python3 python3-pip libglib2.0-0 libgtk2.0-dev libgl1-mesa-glx python3-pyqt5 && \
+    apt-get install -y build-essential git wget python3 python3-pip python3-qt5 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \
     apt-get autoremove -y --purge && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ FROM nvidia/cuda:11.4.0-base-ubuntu20.04
 # Install packages and register python3 as python
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update -y && apt-get install -y dialog apt-utils && \
-    apt-get install -y build-essential git wget python3-pip python3-pyqt5 && \
+    apt-get install -y build-essential git wget python3-pip python3-pyqt5 xvfb python3-pytest-xvfb && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \
     apt-get autoremove -y --purge && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-ENV QT_DEBUG_PLUGINS=1
+
 # Install each piece of external software that Ot2Rec calls
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install packages and register python3 as python
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update -y && apt-get install -y dialog apt-utils && \
-    apt-get install -y build-essential git wget python3 python3-pip python3-pyqt5 && \
+    apt-get install -y build-essential git wget python3-pip python3-pyqt5 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \
     apt-get autoremove -y --purge && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ FROM nvidia/cuda:11.4.0-base-ubuntu20.04
 # Install packages and register python3 as python
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update -y && apt-get install -y dialog apt-utils && \
-    apt-get install -y build-essential git wget python3-pip python3-pyqt5 xvfb && \
+    apt-get install -y build-essential git wget python3-pip python3-pyqt5 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \
     apt-get autoremove -y --purge && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-
+ENV QT_DEBUG_PLUGINS=1
 # Install each piece of external software that Ot2Rec calls
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@
 FROM nvidia/cuda:11.4.0-base-ubuntu20.04
 
 # Install packages and register python3 as python
-# RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-RUN apt-get update -y && apt-get install -y dialog apt-utils && \
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update -y && apt-get install -y dialog apt-utils && \
     apt-get install -y build-essential git wget python3-pip python3-pyqt5 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install packages and register python3 as python
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update -y && apt-get install -y dialog apt-utils && \
-    apt-get install -y build-essential git wget python3 python3-pip python3-qt5 && \
+    apt-get install -y build-essential git wget python3 python3-pip python3-pyqt5 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \
     apt-get autoremove -y --purge && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@
 
 FROM nvidia/cuda:11.4.0-base-ubuntu20.04
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Install packages and register python3 as python
 # RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
 RUN apt-get update -y && apt-get install -y dialog apt-utils && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ FROM nvidia/cuda:11.4.0-base-ubuntu20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install packages and register python3 as python
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update -y && apt-get install -y dialog apt-utils && \
+# RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+RUN apt-get update -y && apt-get install -y dialog apt-utils && \
     apt-get install -y build-essential git wget python3-pip python3-pyqt5 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM nvidia/cuda:11.4.0-base-ubuntu20.04
 # Install packages and register python3 as python
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update -y && apt-get install -y dialog apt-utils && \
-    apt-get install -y build-essential git wget python3-pip python3-pyqt5 && \
+    apt-get install -y build-essential git wget python3-pip python3-pyqt5 xvfb && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \
     apt-get autoremove -y --purge && apt-get clean -y && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes broken CI pipeline after MagicGUI was introduced 

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added `python3-pyqt5 xvfb python3-pytest-xvfb` to the Docker install, which runs the test suite with xvfb, allowing tests with GUIs to be run without windows popping up

## Related Issue
Fixes #47

## How Has This Been Tested?
CI - Build & Test Container now runs successfully 
