### PR TITLE
Aretomo and Savu enhancements

### DIFF
--- a/src/Ot2Rec/align.py
+++ b/src/Ot2Rec/align.py
@@ -462,21 +462,26 @@ PLUGIN METHODS
 """
 
 
-def create_yaml():
+def create_yaml(args_in=None):
     """
     Subroutine to create new yaml file for IMOD newstack / alignment
     """
     # Parse user inputs
-    args = mgMod.get_args_align.show(run=True)
+    if args_in is None:  # default case, o2r.imod.new
+        logger = logMod.Logger(log_path="o2r_imod_align.log")
+        args = mgMod.get_args_align.show(run=True)
+    else:  # to create stacks for aretomo
+        args = args_in
+        logger = logMod.Logger(log_path="o2r_imod_stack_creation.log")
 
     # Create the yaml file, then automatically update it
     prmMod.new_align_yaml(args)
-    update_yaml(args)
+    update_yaml(args, logger)
 
     logger(message="IMOD alignment metadata file created.")
 
 
-def update_yaml(args):
+def update_yaml(args, logger):
     """
     Subroutine to update yaml file for IMOD newstack / alignment
 

--- a/src/Ot2Rec/aretomo.py
+++ b/src/Ot2Rec/aretomo.py
@@ -20,6 +20,7 @@ from glob import glob
 import warnings
 from icecream import ic
 from pathlib import Path
+from tqdm import tqdm
 
 import yaml
 
@@ -180,15 +181,18 @@ class AreTomo:
                                      encoding='ascii',
                                      check=True,
                                      )
-        print(aretomo_run.stdout)
+        self.logObj(f"\nStdOut:{aretomo_run.stdout}\n")
+        self.logObj(f"\nStdErr:{aretomo_run.stderr}\n")
 
     def run_aretomo_all(self):
         """
         Method to run AreTomo for all ts in process list
         """
-        for i, curr_ts in enumerate(self.params['System']['process_list']):
+        ts_list = self.params['System']['process_list']
+        tqdm_iter = tqdm(ts_list, ncols=100)
+        for i, curr_ts in enumerate(tqdm_iter):
+            tqdm_iter.set_description(f"Processing TS {curr_ts}...")
             self._run_aretomo(i)
-            print(f"Ran AreTomo on {self.proj_name}_{curr_ts}")
         self.export_metadata()
 
     def export_metadata(self):
@@ -239,13 +243,14 @@ def _create_stacks_with_imod(args):
                 args_pass=[args["project_name"]])
             print("Created stacks for input to AreTomo")
         except:
-            print("IMOD might not be loaded")
+            warnings.warn("Stacks could not be created, IMOD might not be loaded")
 
 
 def _find_files_with_ext(ext, rootname, suffix, directory):
     search_term = (f"{directory}/{rootname}_*{suffix}/"
                    f"{rootname}_*{suffix}{ext}")
     file_list = glob(search_term)
+    file_list.sort()
 
     if len(file_list) == 0:
         warnings.warn(
@@ -342,9 +347,6 @@ def update_yaml(args):
 
         # Set output mrc
         output_lookup = {0: "_ali.mrc", 2: "_rec.mrc"}
-        # out_file_list = [
-        #     (f"{os.path.splitext(file)[0]}"
-        #      f"{output_lookup[args['aretomo_mode']]}") for file in st_file_list]
         out_file_list = [
             (f"{aretomo_params.params['System']['output_path']}/"
              f"{os.path.splitext(os.path.basename(file))[0]}/"
@@ -367,12 +369,16 @@ def update_yaml(args):
 
         # Set AngFile
         if args["tilt_angles"] == "":
-            tlt_file_list = _find_files_with_ext(
-                ".tlt",
-                rootname,
-                suffix,
-                str(args["input_mrc_folder"])
-            )
+            # NOTE: sometimes if .fid.tlt files are present these are accidentally found too.
+            # Temp fix
+            # tlt_file_list = _find_files_with_ext(
+            #     ".tlt",
+            #     rootname,
+            #     suffix,
+            #     str(args["input_mrc_folder"])
+            # )
+            tlt_file_list = [f"{f.strip('_ali.mrc')}.tlt" for f in st_file_list]
+
             aretomo_params.params["AreTomo_setup"]["tilt_angles"] = tlt_file_list
         else:
             tlt_file_list = args["tilt_angles"]
@@ -384,7 +390,10 @@ def update_yaml(args):
 
         # Set output mrc
         out_file_list = [
-            f"{os.path.splitext(file)[0]}_rec.mrc" for file in st_file_list
+            (f"{aretomo_params.params['System']['output_path']}/"
+             f"{os.path.splitext(os.path.basename(file))[0].strip('_ali')}/"
+             f"{os.path.splitext(os.path.basename(file))[0]}"
+             f"_rec.mrc") for file in st_file_list
         ]
         aretomo_params.params["AreTomo_setup"]["output_mrc"] = out_file_list
 

--- a/src/Ot2Rec/aretomo.py
+++ b/src/Ot2Rec/aretomo.py
@@ -316,9 +316,6 @@ def update_yaml(args):
     # aretomo_params.params['AreTomo_kwargs'] = kwargs
 
     if args["aretomo_mode"] != 1:  # for workflows with alignment
-        # Create input stacks from motioncor images
-        _create_stacks_with_imod(args)
-
         # Set InMrc
         st_file_list = _find_files_with_ext(
             ".st",
@@ -326,6 +323,17 @@ def update_yaml(args):
             suffix,
             str(args["input_mrc_folder"])
         )
+
+        if len(st_file_list) == 0:  # assume that input_mrc_folder is from motioncor
+            # Create input stacks from motioncor images
+            _create_stacks_with_imod(args)
+            st_file_list = _find_files_with_ext(
+                ".st",
+                rootname,
+                suffix,
+                str(args["output_path"])
+            )
+
         aretomo_params.params["AreTomo_setup"]["input_mrc"] = st_file_list
 
         # Set AngFile
@@ -336,10 +344,17 @@ def update_yaml(args):
                 suffix,
                 str(args["input_mrc_folder"])
             )
-            aretomo_params.params["AreTomo_setup"]["tilt_angles"] = tlt_file_list
+            if len(tlt_file_list) == 0: # assume that input_mrc_folder is from motioncor
+                tlt_file_list = _find_files_with_ext(
+                    ".rawtlt",
+                    rootname,
+                    suffix,
+                    str(args["output_path"])
+                )
         else:
             tlt_file_list = args["tilt_angles"]
-            aretomo_params.params["AreTomo_setup"]["tilt_angles"] = tlt_file_list
+
+        aretomo_params.params["AreTomo_setup"]["tilt_angles"] = tlt_file_list
 
         # Set process list
         ts_list = _get_process_list(st_file_list, rootname, suffix, ".st")

--- a/src/Ot2Rec/aretomo.py
+++ b/src/Ot2Rec/aretomo.py
@@ -16,13 +16,13 @@
 import argparse
 import os
 import subprocess
-from glob import glob
 import warnings
-from icecream import ic
+from glob import glob
 from pathlib import Path
-from tqdm import tqdm
 
 import yaml
+from icecream import ic
+from tqdm import tqdm
 
 from . import align
 from . import logger as logMod

--- a/src/Ot2Rec/aretomo.py
+++ b/src/Ot2Rec/aretomo.py
@@ -232,11 +232,11 @@ def _update_volz(args, aretomo_params):
 def _create_stacks_with_imod(args):
     # Uses align to create the InMrc and AngFile in correct form
         try:
-            align.create_yaml([
-                args["project_name"],
-                str(args["rot_angle"]),
-                '-o',
-                args["output_path"]])
+            args_in_align = mgMod.get_args_align
+            args_in_align.project_name.value = args["project_name"]
+            args_in_align.rot_angle.value = args["rot_angle"]
+            args_in_align.output_folder.value = args["output_path"]
+            align.create_yaml(args_in=args_in_align)
             align.run(
                 newstack=True,
                 do_align=False,

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -269,14 +269,27 @@ def update_yaml(args):
 
     # Find stack files
     st_file_list = glob(f'{parent_path}/{rootname}_*{suffix}/{rootname}*_{suffix}{imod_suffix}.{ext}')
+    st_file_list.sort()
 
     # Find tlt files
-    # tlt_file_list = glob(f'{parent_path}/{rootname}_*{suffix}/{rootname}_*{suffix}.tlt')
-    tlt_file_list = [st_file.replace(f'_{imod_suffix}.{ext}', '.tlt') for st_file in st_file_list]
+    tlt_file_list_raw = glob(f'{parent_path}/{rootname}_*{suffix}/*.tlt')
+    tlt_file_list = []
+    for tltfile in tlt_file_list_raw:
+        if tltfile.endswith("fid.tlt") is False:  # remove fid.tlt files
+            tlt_file_list.append(tltfile)
+    tlt_file_list.sort()
+    # tlt_file_list = [st_file.replace(f'_{imod_suffix}.{ext}', '.tlt') for st_file in st_file_list]
 
     # Extract tilt series number
     ts_list = [int(i.split('/')[-1].replace(f'{rootname}_', '').replace(f'_{suffix}{imod_suffix}.{ext}', ''))
                for i in st_file_list]
+
+    # Ensure number of st == tlt files
+    if len(st_file_list) != len(tlt_file_list):
+        raise ValueError(
+            f"Inconsistent number of aligned TS ({len(st_file_list)}) and "
+            f"tlt ({len(tlt_file_list)}) files."
+        )
 
     # Read in and update YAML parameters
     savu_yaml_name = args.project_name.value + '_savurecon.yaml'

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -18,14 +18,15 @@ import os
 import subprocess
 from glob import glob
 
-import yaml
 import mrcfile
+import yaml
+from tqdm import tqdm
 
-from . import metadata as mdMod
-from . import user_args as uaMod
-from . import magicgui as mgMod
 from . import logger as logMod
+from . import magicgui as mgMod
+from . import metadata as mdMod
 from . import params as prmMod
+from . import user_args as uaMod
 
 
 class SavuRecon:
@@ -177,7 +178,7 @@ class SavuRecon:
                                   encoding='ascii',
                                   check=True,
                                   )
-        print(savu_run.stdout)
+        self.logObj(savu_run.stdout)
 
     def _dummy_runner(self, i):
         """
@@ -196,7 +197,10 @@ class SavuRecon:
         """
         Method to run savurecon_stack for all ts in process list
         """
-        for i, curr_ts in enumerate(self.params['System']['process_list']):
+        ts_list = self.params['System']['process_list']
+        tqdm_iter = tqdm(ts_list, ncols=100)
+        for i, curr_ts in enumerate(tqdm_iter):
+            tqdm_iter.set_description(f"Processing TS {curr_ts}...")
             self._create_savurecon_process_list(i)
             self._run_savurecon(i)
             # self._dummy_runner(i)
@@ -208,7 +212,7 @@ class SavuRecon:
                 f'{self.md_out["savu_output_dir"][curr_ts]}/*/*.mrc'
             )[0]
 
-            print(f"Savu reconstruction complete for {self.proj_name}_{curr_ts}")
+            print(f"Savu reconstruction complete for {self.proj_name}_{curr_ts}\n")
         self.export_metadata()
 
     def export_metadata(self):


### PR DESCRIPTION
# Changes

## AreTomo

- **bugfix** | IMOD create stacks from the align module is now run by AreTomo align if the input mrc folder does not contain .st files
- **bugfix** | fid.tlt files from IMOD are not included in the tlt file list
- **bugfix** | Aligned stacks saved in the correct location in output folder
- **enhancement** | Progress bar
- **enhancement** | StdOut saved to log file

## Savu

- **bugfix** | fid.tlt files from IMOD are not included in the tlt file list
- **enhancement** | Progress bar
- **enhancement** | StdOut saved to log file