### PR TITLE
Auto exclusion of bad tilts

### DIFF
--- a/conda-build/meta.yaml
+++ b/conda-build/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ot2rec
-  version: 0.3.0
+  version: 0.3.1
 
 source:
   path: ..

--- a/construct.yaml
+++ b/construct.yaml
@@ -1,10 +1,10 @@
 name: Ot2Rec
-version: 0.3.0
+version: 0.3.1
 company: Rosalind Franklin Institute
 channels:
   - https://conda.anaconda.org/conda-forge
   - file:///usr/share/miniconda3/conda-bld/
 specs:
   - python 3.9.*
-  - Ot2Rec 0.3.0
+  - Ot2Rec 0.3.1
   - conda

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    version='0.3.0',
+    version='0.3.1',
     name='Ot2Rec',
     description='Ot2Rec',
     url='https://github.com/rosalindfranklininstitute/Ot2Rec',
@@ -48,6 +48,9 @@ setup(
 
             "o2r.mc.new=Ot2Rec.motioncorr:create_yaml",
             "o2r.mc.run=Ot2Rec.motioncorr:run",
+
+            "o2r.excludebadtilts.new=Ot2Rec.exclude_bad_tilts:create_yaml",
+            "o2r.excludebadtilts.run=Ot2Rec.exclude_bad_tilts:run",
 
             "o2r.ctffind.new=Ot2Rec.ctffind:create_yaml",
             "o2r.ctffind.run=Ot2Rec.ctffind:run",

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
 
             "o2r.excludebadtilts.new=Ot2Rec.exclude_bad_tilts:create_yaml",
             "o2r.excludebadtilts.run=Ot2Rec.exclude_bad_tilts:run",
+            "o2r.recombinebadtilts=Ot2Rec.exclude_bad_tilts:recombine_bad_tilts",
 
             "o2r.ctffind.new=Ot2Rec.ctffind:create_yaml",
             "o2r.ctffind.run=Ot2Rec.ctffind:run",

--- a/src/Ot2Rec/exclude_bad_tilts.py
+++ b/src/Ot2Rec/exclude_bad_tilts.py
@@ -148,13 +148,8 @@ class ExcludeBadTilts:
                 f".rawtlt file has {len(all_tilt_angles)} lines, should have "
                 f"{img.shape[0]} lines instead.")
 
-        # Write dict of index:excluded tilt angles to separate file
-        excluded_ta_file = rawtlt_file.replace(".rawtlt", "_excl.rawtlt")
-        with open(excluded_ta_file, "w") as f:
-            yaml.dump(tilt_angles_to_exclude, f, indent=4, sort_keys=False)
-
         # Create stack of excluded tilts
-        exclude_filename = st_file.replace(".st", "_excl.st")
+        exclude_filename = st_file.replace(".st", ".excl")
         with mrcfile.new_mmap(
             exclude_filename,
             shape=(len(tilts_to_exclude), img.shape[1], img.shape[2]),
@@ -417,4 +412,4 @@ def recombine_bad_tilts():
     tqdm_iter = tqdm(ts_list, ncols=100)
     for i, curr_ts in enumerate(tqdm_iter):
         tqdm_iter.set_description(f"Recombining bad tilts from TS {curr_ts}")
-        _recombine_tilt_one_ts(i, ebt_config, ebt_mdout)
+        _recombine_tilt_one_ts(i, ebt_config.params, ebt_mdout)

--- a/src/Ot2Rec/exclude_bad_tilts.py
+++ b/src/Ot2Rec/exclude_bad_tilts.py
@@ -1,0 +1,305 @@
+# Copyright 2023 Rosalind Franklin Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+import argparse
+import os
+
+import mrcfile
+import numpy as np
+import yaml
+from tqdm import tqdm
+from glob import glob
+
+from . import logger as logMod
+from . import magicgui as mgMod
+from . import params as prmMod
+
+
+class ExcludeBadTilts:
+    """
+    Class encapsulating a ExcludeBadTilts object
+
+    This class excludes very bright/dark "bad" tilts / projections
+    which are normally seen at large tilt angles.
+    Excluded projections are taken out of the .st files after motion correction
+    and before alignment. These projections are kept in a separate .mrc stack.
+    The .tlt files are also edited accordingly.
+
+    The <proj_name>_excludebadtilt_mdout.yaml file contains details of the removed
+    tilts. These will be parsed into the report later.
+    """
+
+    def __init__(
+        self,
+        project_name: str,
+        params_in: prmMod.Params,
+        logger_in: logMod.Logger,
+    ):
+        """Initialises a ExcludeBadTilts object
+
+        Args:
+            project_name (str): name of current project
+            params_in (prmMod.Params): parameters for removing bad tilts
+            logger_in (logMod.Logger): keep record of progress and errors
+        """
+
+        self.proj_name = project_name
+        self.pObj = params_in
+        self.params = self.pObj.params
+        self.logObj = logger_in
+        self.md_out = {}
+        self._get_internal_metadata()
+              
+        # Set metadata dicts
+        self.md_out["Excluded_Tilt_Index"] = {}
+        self.md_out["Excluded_St_Files"] = {}
+        self.md_out["Excluded_Tilt_Angles"] = {}
+
+    def _get_internal_metadata(self):
+        """Prepare internal metadata from params object
+        """
+
+        # Process list
+        self.md_out["process_list"] = dict(
+            zip(
+                range(
+                    1,
+                    len(self.params["System"]["process_list"]) + 1,
+                ),
+                self.params["System"]["process_list"]
+            )
+        )
+
+    def _determine_tilts_to_exclude(
+        self,
+        img: np.ndarray,
+    ) -> list:
+        """Determines which tilts to exclude based on user parameters
+
+        Args:
+            img (np.ndarray): (proj, x, y) of tilt series
+
+        Returns:
+            list: list of index of tilts to exclude (starts at 0)
+        """
+        stack_mean = np.mean(img)
+        stack_stdev = np.std(img)
+        exclude_factor = float(self.params["EBT_setup"]["exclude_factor"])
+        min_accept = stack_mean - (exclude_factor * stack_stdev)
+        max_accept = stack_mean + (exclude_factor * stack_stdev)
+
+        tilts_to_exclude = []
+        for proj in range(img.shape[0]):
+            tilt_mean = np.mean(img[proj,:,:])
+            if (tilt_mean < min_accept) or (tilt_mean > max_accept):
+                tilts_to_exclude.append(proj)
+        
+        return tilts_to_exclude            
+
+    def _exclude_tilt_one_ts(
+        self,
+        i: int
+    ):
+        """Excludes tilts from one tilt series, saves excluded tilts as a
+        separate .mrc file and edits .tlt accordingly. Old .tlt file is
+        renamed to *_original.tlt. Index (starts at 0) of excluded tilts saved
+        to <proj_name>_exclude_bad_tilts_mdout.yaml
+
+        Args:
+            i (int): Index of tilt series on the process list
+        """
+        # Read image and determine tilts to exclude
+        st_file = self.params["EBT_setup"]["input_mrc"][i]
+        with mrcfile.mmap(st_file) as mrc:
+            img = mrc.data
+        
+        tilts_to_exclude = self._determine_tilts_to_exclude(img)
+        self.md_out["Excluded_Tilt_Index"][i] = tilts_to_exclude
+
+        
+        # Take excluded tilt angles out of rawtlt file
+        rawtlt_file = self.params["EBT_setup"]["tilt_angles"][i]
+        tilt_angles_to_exclude = {}
+        with open(rawtlt_file, "r") as f:
+            all_tilt_angles = f.readlines()
+        if len(all_tilt_angles) == img.shape[0]:
+            for tilt in tilts_to_exclude:
+                tilt_angles_to_exclude[tilt] = all_tilt_angles[tilt]
+            for tilt in sorted(tilts_to_exclude, reverse=True):
+                del all_tilt_angles[tilt]
+            with open(rawtlt_file, "w+") as f:
+                f.writelines(all_tilt_angles)
+            self.md_out["Excluded_Tilt_Angles"][i] = tilt_angles_to_exclude
+
+        else:
+            raise ValueError(
+                f".rawtlt file has {len(all_tilt_angles)} lines, should have "
+                f"{img.shape[0]} lines instead.")
+
+        # Write dict of index:excluded tilt angles to separate file
+        excluded_ta_file = rawtlt_file.replace(".rawtlt", "_excl.rawtlt")
+        with open(excluded_ta_file, "w") as f:
+            yaml.dump(tilt_angles_to_exclude, f, indent=4, sort_keys=False)
+        
+        # Create stack of excluded tilts
+        exclude_filename = st_file.replace(".st", "_excl.st")
+        with mrcfile.new_mmap(
+            exclude_filename,
+            shape=(len(tilts_to_exclude), img.shape[1], img.shape[2]),
+        ) as mrc:
+            excluded_stack = img[tilts_to_exclude, :, :]
+            mrc.set_data(excluded_stack)
+        self.md_out["Excluded_St_Files"][i] = exclude_filename
+
+    def run_exclude_bad_tilts(self):
+        """Method to exclude bad tilts for all tilt series
+        """
+        ts_list = self.params["System"]["process_list"]
+        tqdm_iter = tqdm(ts_list, ncols=100)
+        for i, curr_ts in enumerate(tqdm_iter):
+            tqdm_iter.set_description(f"Removing bad tilts from TS {curr_ts}")
+            self._exclude_tilt_one_ts(i)
+        self.export_metadata()
+
+    def export_metadata(self):
+        """Method to export metadata as
+        <proj_name>_exclude_bad_tilts_mdout.yaml
+        """
+
+        yaml_file = f"{self.proj_name}_exclude_bad_tilts_mdout.yaml"
+        with open(yaml_file, "w") as f:
+            yaml.dump(
+                self.md_out,
+                f,
+                indent=4,
+                sort_keys=False,
+            )
+
+
+def update_yaml(args: dict):
+    """Updates yaml file <proj_name>_exclude_bad_tilts.yaml
+
+    Args:
+        args (dict): User arguments from magicgui
+    """
+    ebt_yaml_name = f"{args.project_name.value}_exclude_bad_tilts.yaml"
+
+    ebt_params = prmMod.read_yaml(
+        project_name=args.project_name.value,
+        filename=ebt_yaml_name
+    )
+
+    # Get input mrc's
+    st_file_list = glob(
+        f"{args.input_mrc_folder.value}/*/*.st"
+    )
+    st_file_list.sort()
+
+    # Get tilt angle files
+    rawtlt_file_list = glob(
+        f"{args.input_mrc_folder.value}/*/*.rawtlt"
+    )
+    rawtlt_file_list.sort()
+
+    # Ensure # st = # rawtlt
+    if len(st_file_list) != len(rawtlt_file_list):
+        raise ValueError(
+            f"Inconsistent number of aligned TS ({len(st_file_list)}) and "
+            f"tlt ({len(rawtlt_file_list)}) files."
+        )
+    
+    else:
+        ebt_params.params["EBT_setup"]["input_mrc"] = st_file_list
+        ebt_params.params["EBT_setup"]["tilt_angles"] = rawtlt_file_list
+
+    # Extract tilt series number
+    ts_list = [
+        int(os.path.basename(i).split("_")[-1].split(".")[0]) 
+        for i in st_file_list
+    ]
+
+    # Set process list
+    ebt_params.params["System"]["process_list"] = ts_list
+
+    # Add remaining magicgui values to ebt_params
+    ebt_params.params["EBT_setup"]["create_st_files"] = args.create_st_files.value
+    ebt_params.params["EBT_setup"]["exclude_factor"] = args.exclude_factor.value
+
+    # update and write yaml file
+    with open(ebt_yaml_name, "w") as f:
+        yaml.dump(
+            ebt_params.params,
+            f,
+            indent=4,
+            sort_keys=False,
+        )
+
+
+def create_yaml(args=None):
+    """Subroutine to create new yaml file for excluding bad tilts
+    """
+
+    if args is None:
+        args = mgMod.get_args_exclude_bad_tilts.show(run=True)
+
+    prmMod.new_exclude_bad_tilts_yaml(args)
+    update_yaml(args)
+
+
+def run():
+    """ Method to exclude bad tilts
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "project_name",
+        type=str,
+        help="Name of current project",
+    )
+    run_args = parser.parse_args()
+
+    # check that ebt yaml file exists
+    ebt_yaml = f"{run_args.project_name}_exclude_bad_tilts.yaml"
+    if not os.path.isfile(ebt_yaml):
+        raise IOError(
+            "Error in Ot2Rec.exclude_bad_tilts.run: yaml file not found"
+        )
+
+    # Read in config and metadata
+    ebt_config = prmMod.read_yaml(
+        project_name=run_args.project_name,
+        filename=ebt_yaml,
+    )
+
+    # Create Logger object
+    log_path = "o2r_exclude_bad_tilts.log"
+    try:
+        os.remove(log_path)
+    except:
+        pass
+    logger = logMod.Logger(log_path=log_path)
+
+    # Create Exclude Bad Tilts object
+    ebt_obj = ExcludeBadTilts(
+        project_name=run_args.project_name,
+        params_in=ebt_config,
+        logger_in=logger,
+    )
+
+    # Run exclude bad tilts commands
+    ebt_obj.run_exclude_bad_tilts()
+
+
+def recombine():
+    raise NotImplementedError

--- a/src/Ot2Rec/magicgui.py
+++ b/src/Ot2Rec/magicgui.py
@@ -838,23 +838,21 @@ def get_args_aretomo(
         "label": "Folder containing input mrc's",
         "mode": "d",
     },
-    create_st_files={
-        "label": "Create Stack Files with IMOD?"
+    min_percentile={
+        "label": "Min percentile of stack grey value distribution to include",
+        "min": 0,
+        "max": 100,
     },
-    tilt_angles={
-        "label": "Path to text file containing tilt angles, usually .tlt"
-    },
-    exclude_factor={
-        "label": "Multiplier of stack std dev to include (higher=include more tilts)",
-        "min": 1e-6,
-        "max": 3,
-    },
+    max_percentile={
+        "label": "Max percentile of stack grey value distribution to include",
+        "min": 0,
+        "max": 100,
+    }
 )
 def get_args_exclude_bad_tilts(
         project_name="",
         input_mrc_folder=Path("./stacks"),
-        create_st_files=False,
-        tilt_angles="",
-        exclude_factor=0.5,
+        min_percentile=5,
+        max_percentile=95,
 ):
     return locals()

--- a/src/Ot2Rec/magicgui.py
+++ b/src/Ot2Rec/magicgui.py
@@ -826,3 +826,35 @@ def get_args_aretomo(
         recon_algo="WBP",
 ):
     return locals()
+
+
+@mg(
+    call_button="Create config file",
+    layout="vertical",
+    result_widget=False,
+
+    project_name={"label": "Project name *"},
+    input_mrc_folder={
+        "label": "Folder containing input mrc's",
+        "mode": "d",
+    },
+    create_st_files={
+        "label": "Create Stack Files with IMOD?"
+    },
+    tilt_angles={
+        "label": "Path to text file containing tilt angles, usually .tlt"
+    },
+    exclude_factor={
+        "label": "Multiplier of stack std dev to include (higher=include more tilts)",
+        "min": 1e-6,
+        "max": 3,
+    },
+)
+def get_args_exclude_bad_tilts(
+        project_name="",
+        input_mrc_folder=Path("./stacks"),
+        create_st_files=False,
+        tilt_angles="",
+        exclude_factor=0.5,
+):
+    return locals()

--- a/src/Ot2Rec/params.py
+++ b/src/Ot2Rec/params.py
@@ -363,9 +363,8 @@ def new_exclude_bad_tilts_yaml(args):
 
         "EBT_setup": {
             "input_mrc": None,
-            "tilt_angles": None,
-            "create_st_files" : None,
-            "exclude_factor": None,
+            "min_percentile": None,
+            "max_percentile": None,
         },
     }
 

--- a/src/Ot2Rec/params.py
+++ b/src/Ot2Rec/params.py
@@ -345,6 +345,34 @@ def new_aretomo_yaml(args):
         yaml.dump(aretomo_yaml_dict, f, indent=4, sort_keys=False)
 
 
+def new_exclude_bad_tilts_yaml(args):
+    """
+    Subroutine to create yaml file for excluding bad tilts
+
+    ARGS:
+    args (Namespace) :: Namespace containing user parameter inputs
+    """
+
+    ebt_yaml_name = f"{args.project_name.value}_exclude_bad_tilts.yaml"
+    print(f"{ebt_yaml_name} created")
+
+    ebt_yaml_dict = {
+        "System": {
+            "process_list": None,
+        },
+
+        "EBT_setup": {
+            "input_mrc": None,
+            "tilt_angles": None,
+            "create_st_files" : None,
+            "exclude_factor": None,
+        },
+    }
+
+    with open(ebt_yaml_name, "w") as f:
+        yaml.dump(ebt_yaml_dict, f, indent=4, sort_keys=False)
+
+
 def read_yaml(project_name: str,
               filename: str):
     """

--- a/src/Ot2Rec/recon.py
+++ b/src/Ot2Rec/recon.py
@@ -316,7 +316,7 @@ runtime.Trimvol.any.reorient = <trimvol_reorient>
 
         yaml_file = self.proj_name + '_recon_mdout.yaml'
         meta_dict = self.meta_out.to_dict()
-        meta_dict['recon_algor'] = "SIRT" if self.params["Batchruntomo"]["reconstruction"]["use_sirt"] else "WBP"
+        meta_dict['recon_algor'] = "SIRT" if self.params["BatchRunTomo"]["reconstruction"]["use_sirt"] else "WBP"
 
         with open(yaml_file, 'w') as f:
             yaml.dump(self.meta_out.to_dict(), f, indent=4, sort_keys=False)

--- a/tests/test_exclude_bad_tilts.py
+++ b/tests/test_exclude_bad_tilts.py
@@ -232,3 +232,32 @@ class ExcludeBadTiltsSmokeTest(unittest.TestCase):
             ta,
             np.linspace(-60, 60, 10)
         )
+    
+    def test_EBT_dryrun(self):
+        """Tests that dry run outputs tilts to exclude to yaml
+        """
+        args = self._create_expected_input_args()
+        tmpdir, st = self._create_expected_folder_structure()
+        os.chdir(tmpdir.name)
+
+        exclude_bad_tilts.create_yaml(args)
+
+        params = prmMod.read_yaml(
+            project_name="TS",
+            filename="./TS_exclude_bad_tilts.yaml",
+        )
+
+        ebt_obj = exclude_bad_tilts.ExcludeBadTilts(
+            project_name="TS",
+            params_in=params,
+            logger_in=logMod.Logger("o2r_exclude_bad_tilts.log")
+        )
+
+        ebt_obj.dry_run()
+
+        self.assertTrue(os.path.isfile("TS_EBTdryrun.yaml"))
+        
+        with open("TS_EBTdryrun.yaml", "r") as f:
+            dryrun = yaml.load(f, Loader=yaml.FullLoader)
+        
+        self.assertNotEqual(len(dryrun), 0)

--- a/tests/test_exclude_bad_tilts.py
+++ b/tests/test_exclude_bad_tilts.py
@@ -181,7 +181,7 @@ class ExcludeBadTiltsSmokeTest(unittest.TestCase):
 
         self.assertEqual(
             md["Excluded_St_Files"][0],
-            "stacks/TS_0001/TS_0001_excl.st"
+            "stacks/TS_0001/TS_0001.excl"
         )
 
         self.assertEqual(
@@ -215,7 +215,7 @@ class ExcludeBadTiltsSmokeTest(unittest.TestCase):
         
         exclude_bad_tilts._recombine_tilt_one_ts(
             0,
-            params,
+            params.params,
             md
         )
 

--- a/tests/test_exclude_bad_tilts.py
+++ b/tests/test_exclude_bad_tilts.py
@@ -215,6 +215,7 @@ class ExcludeBadTiltsSmokeTest(unittest.TestCase):
         
         exclude_bad_tilts._recombine_tilt_one_ts(
             0,
+            params.params,
             md
         )
 

--- a/tests/test_exclude_bad_tilts.py
+++ b/tests/test_exclude_bad_tilts.py
@@ -227,7 +227,6 @@ class ExcludeBadTiltsSmokeTest(unittest.TestCase):
         # Check that rawtlt files are recombined correctly
         ta = np.loadtxt(
             fname="stacks/TS_0001/TS_0001.rawtlt",
-            delimiter="\n",
         )
         np.testing.assert_allclose(
             ta,

--- a/tests/test_exclude_bad_tilts.py
+++ b/tests/test_exclude_bad_tilts.py
@@ -1,0 +1,189 @@
+# Copyright 2023 Rosalind Franklin Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import os
+import tempfile
+import unittest
+
+import magicgui
+import mrcfile
+import numpy as np
+import yaml
+
+from Ot2Rec import exclude_bad_tilts
+from Ot2Rec import logger as logMod
+from Ot2Rec import magicgui as mgMod
+from Ot2Rec import params as prmMod
+
+
+class ExcludeBadTiltsSmokeTest(unittest.TestCase):
+
+    def _create_expected_input_args(self):
+        args = magicgui.widgets.FunctionGui(mgMod.get_args_exclude_bad_tilts)
+        args.project_name.value = "TS"
+        args.exclude_factor.value = 0.5
+        
+        return args
+    
+    def _create_expected_folder_structure(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        os.mkdir(f"{tmpdir.name}/stacks")
+        os.mkdir(f"{tmpdir.name}/stacks/TS_0001")
+
+        # .st files
+        st_mrc = f"{tmpdir.name}/stacks/TS_0001/TS_0001.st"
+        with mrcfile.new(st_mrc) as mrc:
+            bad = np.full(
+                shape=(2,2),
+                fill_value=1,
+                dtype="uint8",
+            )
+            good = np.full(
+                shape=(2,2),
+                fill_value=200,
+                dtype="uint8",
+            )
+            mrc.set_data(
+                np.stack(
+                    [bad, good, good, good, good, good, good, good, good, bad],
+                    axis=0,
+                )
+            )
+        
+        # create .rawtlt files
+        rawtlt_file = f"{tmpdir.name}/stacks/TS_0001/TS_0001.rawtlt"
+        tas = np.linspace(-60, 60, 10)
+        with open(rawtlt_file, "w") as f:
+            f.writelines(f"{str(ta)}\n" for ta in tas)
+        
+        return tmpdir
+    
+    def test_yaml_creation(self):
+        """ Test yaml is created with expected input """
+        args = self._create_expected_input_args()
+        tmpdir = self._create_expected_folder_structure()
+        os.chdir(tmpdir.name)
+
+        exclude_bad_tilts.create_yaml(args)
+
+        self.assertTrue(
+            os.path.isfile("./TS_exclude_bad_tilts.yaml")
+        )
+
+        params = prmMod.read_yaml(
+            project_name="TS",
+            filename="./TS_exclude_bad_tilts.yaml"
+        )
+
+        # Ensure process list is not empty
+        self.assertNotEqual(
+            len(params.params["System"]["process_list"]),
+            0
+        )
+
+        tmpdir.cleanup()
+    
+    def test_tilts_exclusion(self):
+        """ Test that the correct tilts are excluded """
+        args = self._create_expected_input_args()
+        tmpdir = self._create_expected_folder_structure()
+        os.chdir(tmpdir.name)
+
+        exclude_bad_tilts.create_yaml(args)
+
+        params = prmMod.read_yaml(
+            project_name="TS",
+            filename="./TS_exclude_bad_tilts.yaml",
+        )
+
+        ebt_obj = exclude_bad_tilts.ExcludeBadTilts(
+            project_name="TS",
+            params_in=params,
+            logger_in=logMod.Logger("o2r_exclude_bad_tilts.log")
+        )
+
+        ebt_obj._exclude_tilt_one_ts(0)
+
+        with mrcfile.mmap("./stacks/TS_0001/TS_0001_excl.st") as mrc:
+            excluded_mrc = mrc.data
+        
+        self.assertEqual(excluded_mrc.shape[0], 2)
+    
+    def test_tilt_angles_exclusion(self):
+        """ Test that the correct tilt angles are removed from the rawtlt """
+
+        args = self._create_expected_input_args()
+        tmpdir = self._create_expected_folder_structure()
+        os.chdir(tmpdir.name)
+
+        exclude_bad_tilts.create_yaml(args)
+
+        params = prmMod.read_yaml(
+            project_name="TS",
+            filename="./TS_exclude_bad_tilts.yaml",
+        )
+
+        ebt_obj = exclude_bad_tilts.ExcludeBadTilts(
+            project_name="TS",
+            params_in=params,
+            logger_in=logMod.Logger("o2r_exclude_bad_tilts.log")
+        )
+
+        ebt_obj._exclude_tilt_one_ts(0)
+
+        with open("./stacks/TS_0001/TS_0001.rawtlt", "r") as f:
+            tas_excluded = f.readlines()
+        
+        self.assertEqual(len(tas_excluded), 8)
+    
+    def test_EBT_metadata(self):
+        """ Test that excluded tilt indices, tilt angles, filenames saved """
+
+        args = self._create_expected_input_args()
+        tmpdir = self._create_expected_folder_structure()
+        os.chdir(tmpdir.name)
+
+        exclude_bad_tilts.create_yaml(args)
+
+        params = prmMod.read_yaml(
+            project_name="TS",
+            filename="./TS_exclude_bad_tilts.yaml",
+        )
+
+        ebt_obj = exclude_bad_tilts.ExcludeBadTilts(
+            project_name="TS",
+            params_in=params,
+            logger_in=logMod.Logger("o2r_exclude_bad_tilts.log")
+        )
+
+        ebt_obj.run_exclude_bad_tilts()
+
+        with open(
+            f"{tmpdir.name}/TS_exclude_bad_tilts_mdout.yaml", "r"
+        ) as f:
+            md = yaml.load(f, Loader=yaml.FullLoader)
+        
+        self.assertEqual(
+            len(md["Excluded_Tilt_Index"][0]), 2
+        )
+
+        self.assertEqual(
+            md["Excluded_St_Files"][0],
+            "stacks/TS_0001/TS_0001_excl.st"
+        )
+
+        self.assertEqual(
+            list(md["Excluded_Tilt_Angles"][0].keys()),
+            [0,9]
+        )

--- a/tests/test_exclude_bad_tilts.py
+++ b/tests/test_exclude_bad_tilts.py
@@ -32,7 +32,8 @@ class ExcludeBadTiltsSmokeTest(unittest.TestCase):
     def _create_expected_input_args(self):
         args = magicgui.widgets.FunctionGui(mgMod.get_args_exclude_bad_tilts)
         args.project_name.value = "TS"
-        args.exclude_factor.value = 0.5
+        args.min_percentile.value = 20
+        args.max_percentile.value = 80
         
         return args
     

--- a/tests/test_exclude_bad_tilts.py
+++ b/tests/test_exclude_bad_tilts.py
@@ -112,7 +112,7 @@ class ExcludeBadTiltsSmokeTest(unittest.TestCase):
 
         ebt_obj._exclude_tilt_one_ts(0)
 
-        with mrcfile.mmap("./stacks/TS_0001/TS_0001_excl.st") as mrc:
+        with mrcfile.mmap("./stacks/TS_0001/TS_0001.excl") as mrc:
             excluded_mrc = mrc.data
         
         with mrcfile.mmap("./stacks/TS_0001/TS_0001.st") as mrc:
@@ -215,7 +215,7 @@ class ExcludeBadTiltsSmokeTest(unittest.TestCase):
         
         exclude_bad_tilts._recombine_tilt_one_ts(
             0,
-            params.params,
+            params,
             md
         )
 


### PR DESCRIPTION
Excludes bad tilts (very bright or very dark) by finding projections which have a mean grey value outside the stack mean +/- exclusion factor * stack stdev.

Bad tilts are removed from the original .st files, but saved in a separate `<ts_name>_excl.st` file.

Rawtlt files are edited accordingly and the removed tilt angles saved in the `mdout.yaml` file.