### PR TITLE
Issue79 Excluding bad tilts bugfixes

### DIFF
--- a/src/Ot2Rec/metadata.py
+++ b/src/Ot2Rec/metadata.py
@@ -22,7 +22,7 @@ import subprocess
 from glob import glob
 
 import yaml
-# import mdocfile as mdf
+import mdocfile as mdf
 import pandas as pd
 from icecream import ic
 

--- a/src/Ot2Rec/metadata.py
+++ b/src/Ot2Rec/metadata.py
@@ -22,7 +22,7 @@ import subprocess
 from glob import glob
 
 import yaml
-import mdocfile as mdf
+# import mdocfile as mdf
 import pandas as pd
 from icecream import ic
 

--- a/tests/test_exclude_bad_tilts.py
+++ b/tests/test_exclude_bad_tilts.py
@@ -177,17 +177,17 @@ class ExcludeBadTiltsSmokeTest(unittest.TestCase):
             md = yaml.load(f, Loader=yaml.FullLoader)
         
         self.assertEqual(
-            len(md["Excluded_Tilt_Index"][0]), 2
+            len(md["Excluded_Tilt_Index"][1]), 2
         )
 
         self.assertEqual(
-            md["Excluded_St_Files"][0],
+            md["Excluded_St_Files"][1],
             "stacks/TS_0001/TS_0001.excl"
         )
 
         self.assertEqual(
-            list(md["Excluded_Tilt_Angles"][0].keys()),
-            [0,9]
+            list(md["Excluded_Tilt_Angles"][1]),
+            [-60.0, 60.0]
         )
     
     def test_EBT_recombine(self):
@@ -290,7 +290,7 @@ class ExcludeBadTiltsSmokeTest(unittest.TestCase):
         )
 
         tilts_to_exclude = {
-            0: [1,2,3,9]
+            1: [1,2,3,9]
         }
 
         with open("TS_EBTdryrun.yaml", "w") as f:


### PR DESCRIPTION
Fixes minor bugs caught during testing with real data

- Changes Excluded_Tilt_Angles in md_out file to be list of tilt angles rather than dict of index:tilt angles for simplicity
- Updates recombinebadtilts function to reflect this change
- Updates tests