### PR TITLE
Api docs

### DIFF
--- a/.github/workflows/api_docs
+++ b/.github/workflows/api_docs
@@ -1,0 +1,52 @@
+# Adapted from https://github.com/mitmproxy/pdoc/blob/main/.github/workflows/docs.yml
+
+name: apidocs
+
+# build the documentation whenever there are new commits on main
+on:
+  push:
+    branches:
+      - dev
+    # Alternative: only build for tags.
+    # tags:
+    #   - '*'
+
+# security: restrict permissions for CI jobs.
+permissions:
+  contents: read
+
+jobs:
+  # Build the documentation and upload the static HTML files as an artifact.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      # ADJUST THIS: install all dependencies (including pdoc)
+      - run: pip install -e .
+      - run: pip install pdoc
+      # ADJUST THIS: build your documentation into docs/.
+      # We use a custom build script for pdoc itself, ideally you just run `pdoc -o docs/ ...` here.
+      - run: pdoc --config='docformat="google"' ./src/Ot2Rec -o ./docs --force
+
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/
+
+  # Deploy the artifact to GitHub pages.
+  # This is a separate job so that only actions/deploy-pages has the necessary permissions.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/src/Ot2Rec/align.py
+++ b/src/Ot2Rec/align.py
@@ -48,11 +48,11 @@ class Align:
         """
         Initialising an Align object
 
-        ARGS:
-        project_name (str) :: name of current project
-        md_in (Metadata)   :: metadata containing images to be put into stack(s) for alignment
-        params_in (Params) :: parameters for stack creation
-        logger_in (Logger) :: logger object to keep record of progress and errors
+        Args:
+            project_name (str): name of current project
+            md_in (Metadata): metadata containing images to be put into stack(s) for alignment
+            params_in (Params): parameters for stack creation
+            logger_in (Logger): logger object to keep record of progress and errors
         """
 
         self.proj_name = project_name
@@ -177,11 +177,11 @@ class Align:
         """
         Method to sort images within a tilt-series according to their tilt angles
 
-        ARGS:
-        curr_ts :: index of the tilt-series currently being processed
+        Args:
+            curr_ts: index of the tilt-series currently being processed
 
-        RETURNS:
-        pandas df
+        Returns:
+            pd.DataFrame
         """
 
         # Extract metadata for current TS
@@ -405,11 +405,11 @@ comparam.align.tiltalign.WeightWholeTracks = <weight_contours>
         """
         Method to get command to run batchtomo for alignment
 
-        ARGS:
-        curr_ts :: index of the tilt-series currently being processed
+        Args:
+            curr_ts: index of the tilt-series currently being processed
 
-        RETURNS:
-        list
+        Returns:
+            list
         """
 
         # Get indices of usable CPUs
@@ -527,8 +527,8 @@ def update_yaml(args, logger):
     """
     Subroutine to update yaml file for IMOD newstack / alignment
 
-    ARGS:
-    args (Namespace) :: Namespace generated with user inputs
+    Args:
+        args (Namespace): Namespace generated with user inputs
     """
     # Check if align and motioncorr yaml files exist
     align_yaml_name = args.project_name.value + '_align.yaml'
@@ -590,7 +590,7 @@ def update_yaml(args, logger):
 def create_yaml_stacked():
     """
     Subroutine to create new yaml file for IMOD newstack / alignment
-    prestack (bool) :: if stacks already exist
+    prestack (bool) : if stacks already exist
     """
     # Parse user inputs
     args = mgMod.get_args_align_ext.show(run=True)
@@ -604,8 +604,8 @@ def update_yaml_stacked(args):
     """
     Method to update yaml file for IMOD newstack / alignment --- if stacks already exist
 
-    ARGS:
-    args (Namespace) :: User input parameters
+    Args:
+        args (Namespace): User input parameters
     """
     project_name = args.project_name.value
     parent_path = str(args.input_folder.value)
@@ -647,10 +647,10 @@ def run(newstack=False, do_align=True, ext=False, args_pass=None, exclusive=True
     """
     Method to run IMOD newstack / alignment
 
-    ARGS:
-    newstack (bool) :: whether to create new stack(s)
-    do_align (bool) :: whether to perform IMOD alignment
-    ext (bool)      :: whether external stack(s) are available and to be used
+    Args:
+        newstack (bool): whether to create new stack(s)
+        do_align (bool): whether to perform IMOD alignment
+        ext (bool): whether external stack(s) are available and to be used
     """
     # logger = logMod.Logger(log_path="o2r_imod_align.log")
 

--- a/src/Ot2Rec/aretomo.py
+++ b/src/Ot2Rec/aretomo.py
@@ -45,10 +45,10 @@ class AreTomo:
         """
         Initialising a AreTomo object
 
-        ARGS:
-        project_name (str) :: name of current project
-        params_in (Params) :: parameters for stack creation
-        logger_in (Logger) :: logger object to keep record of progress and errors
+        Args:
+            project_name (str): name of current project
+            params_in (Params): parameters for stack creation
+            logger_in (Logger): logger object to keep record of progress and errors
         """
 
         self.proj_name = project_name
@@ -107,8 +107,8 @@ class AreTomo:
         """
         Method to get command to set up AreTomo align
 
-        ARGS:
-        i (int): The i-th tilt series to process
+        Args:
+            i (int): The i-th tilt series to process
         """
         cmd = [
             'AreTomo',
@@ -134,8 +134,8 @@ class AreTomo:
         """
         Method to get command to set up AreTomo reconstruction
 
-        ARGS:
-        i (int): The i-th tilt series to process
+        Args:
+            i (int): The i-th tilt series to process
         """
         cmd = [
             'AreTomo',
@@ -346,8 +346,8 @@ def update_yaml(args):
     Method to update yaml file for AreTomo
 
     Args:
-    args (Namespace) :: Namespace containing user inputs
-    kwargs (list) :: List of extra inputs, used for extra AreTomo arguments
+        args (Namespace): Namespace containing user inputs
+        kwargs (list): List of extra inputs, used for extra AreTomo arguments
                      beyond those implemented here
     """
     # Read in YAML, set mundane things

--- a/src/Ot2Rec/ctffind.py
+++ b/src/Ot2Rec/ctffind.py
@@ -64,11 +64,11 @@ class ctffind():
         """
         Initialising a ctffind object
 
-        ARGS:
-        project_name (str) :: name of current project
-        md_in (Metadata)   :: metadata containing information of tilt-series to be processed
-        params_in (Params) :: params object containing configurations for ctffind
-        logger_in (Logger) :: logger object for recording ctffind process
+        Args:
+            project_name (str): name of current project
+            md_in (Metadata): metadata containing information of tilt-series to be processed
+            params_in (Params): params object containing configurations for ctffind
+            logger_in (Logger): logger object for recording ctffind process
         """
 
         self.proj_name = project_name
@@ -171,8 +171,8 @@ class ctffind():
         """
         Function to return command for CTFfind
 
-        ARGS:
-        ts (int) :: index of curent tilt-series
+        Args:
+            ts (int): index of curent tilt-series
         """
 
         self.cmd = [self.params['ctffind']['ctffind_path']]
@@ -297,8 +297,8 @@ def update_yaml(args):
     """
     Subroutine to update yaml file for ctffind
 
-    ARGS:
-    args (Namespace) :: Arguments obtained from user
+    Args:
+        args (Namespace): Arguments obtained from user
     """
     logger = logMod.Logger(log_path="o2r_ctffind.log")
 

--- a/src/Ot2Rec/ctfsim.py
+++ b/src/Ot2Rec/ctfsim.py
@@ -91,12 +91,12 @@ def calculate_k_grids(image_size, pixel_size):
     """
     Method to calculate alpha_g (angle between g vector and horizontal axis) and norm2 on reciprocal grid
 
-    ARGS:
-    image_size (list) :: size of original image
-    pixel_size (float) :: pixel size of original image
+    Args:
+        image_size (list): size of original image
+        pixel_size (float): pixel size of original image
 
-    OUTPUTS:
-    ndarray, ndarray
+    Returns:
+        ndarray, ndarray
     """
 
     # Create k-space coordinate grid

--- a/src/Ot2Rec/logger.py
+++ b/src/Ot2Rec/logger.py
@@ -34,8 +34,8 @@ class Logger():
         """
         Initialise Logger object
 
-        ARGS:
-        log_path :: Path to the log file
+        Args:
+            log_path: Path to the log file
         """
         self.log_path = log_path
 
@@ -56,10 +56,10 @@ class Logger():
         """
         Send a string to stdout and log file one process at a time.
 
-        ARGS:
-        message  :: message to be output to file
-        level    :: type of log (info / warning / error)
-        stdout   :: whether to output to shell
+        Args:
+            message: message to be output to file
+            level: type of log (info / warning / error)
+            stdout: whether to output to shell
         """
 
         logging.log(level=self.LEVELS[level.lower()],

--- a/src/Ot2Rec/magicgui.py
+++ b/src/Ot2Rec/magicgui.py
@@ -54,19 +54,19 @@ def get_args_new_proj(
     """
     Function to add arguments to parser for new project
 
-    ARGS:
-    project_name (str)    :: Name of current project
-    source_folder (str)   :: Path to folder with raw images (Default: ../raw/)
-    folder_prefix (str)   :: Common prefix of raw tilt series folder(s)
-    file_prefix (str)     :: Common prefix of raw image files (Default: project)
-    ext (str)             :: Extension of raw image files (Default: mrc)
-    stack_field (int)     :: Field number of tilt series indices (Default: 0)
-    index_field (int)     :: Field number of image indices (Default: 1)
-    tiltangle_field (int) :: Field number of tilt angles (Default: 2)
-    no_mdoc (bool)        :: True if no MDOC file provided (Default: False)
+    Args:
+        project_name (str): Name of current project
+        source_folder (str): Path to folder with raw images (Default: ../raw/)
+        folder_prefix (str): Common prefix of raw tilt series folder(s)
+        file_prefix (str): Common prefix of raw image files (Default: project)
+        ext (str): Extension of raw image files (Default: mrc)
+        stack_field (int): Field number of tilt series indices (Default: 0)
+        index_field (int): Field number of image indices (Default: 1)
+        tiltangle_field (int): Field number of tilt angles (Default: 2)
+        no_mdoc (bool): True if no MDOC file provided (Default: False)
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
 
     return locals()
@@ -127,27 +127,27 @@ def get_args_mc2(
     """
     Function to add arguments to parser for MotionCor
 
-    ARGS:
-    project_name (str)    :: Name of current project
-    pixel_size (float)    :: Image pixel size in Angstroms
-    output_folder (str)   :: Path to folder for storing motion-corrected images (Default: ./motioncor/)
-    file_prefix (str)     :: Common prefix of raw image files (Default: project)
-    no_gpu (bool)         :: Use CPU only for motion-correction
-    jobs_per_gpu (int)    :: Number of job instance(s) per GPU
-    gpu_mem_usage (float) :: MotionCor2 GPU memory usage
-    exec_path (str)       :: Path to MotionCor2 executable
-    use_gain (bool)       :: Whether to use gain reference file
-    gain (str)            :: Path to gain reference file (leave blank if use_gain==False)
-    super_res (bool)      :: True if super-resolution images used
-    discard_top (int)     :: Number of frames discarded from top per image
-    discard_bottom (int)  :: Number of frames discarded from bottom per image
-    tolerance (float)     :: Threshold of alignment errors in pixels
-    max_iter (int)        :: Maximum number of iterations performed by MotionCor2
-    patch_size (int)      :: Size of patches used in alignment
-    use_subgroups (bool)  :: Use subgroups in alignment
+    Args:
+        project_name (str): Name of current project
+        pixel_size (float): Image pixel size in Angstroms
+        output_folder (str): Path to folder for storing motion-corrected images (Default: ./motioncor/)
+        file_prefix (str): Common prefix of raw image files (Default: project)
+        no_gpu (bool): Use CPU only for motion-correction
+        jobs_per_gpu (int): Number of job instance(s) per GPU
+        gpu_mem_usage (float): MotionCor2 GPU memory usage
+        exec_path (str): Path to MotionCor2 executable
+        use_gain (bool): Whether to use gain reference file
+        gain (str): Path to gain reference file (leave blank if use_gain==False)
+        super_res (bool): True if super-resolution images used
+        discard_top (int): Number of frames discarded from top per image
+        discard_bottom (int): Number of frames discarded from bottom per image
+        tolerance (float): Threshold of alignment errors in pixels
+        max_iter (int): Maximum number of iterations performed by MotionCor2
+        patch_size (int): Size of patches used in alignment
+        use_subgroups (bool): Use subgroups in alignment
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     return locals()
 
@@ -198,23 +198,23 @@ def get_args_ctffind(
     """
     Function to add arguments to parser for CTFFind
 
-    ARGS:
-    project_name (str)           :: Name of current project
-    output_folder (str)          :: Path to folder for storing CTFFind4 outputs
-    file_prefix (str)            :: Common prefix of raw image files (Default: project)
-    exec_path (str)              :: Path to IMOD executable
-    voltage (float)              :: Electron beam voltage in keV
-    spherical_aberration (float) :: Spherical aberration of objective lens in mrad
-    amp_contrast (float)         :: Relative amplitude contrast w1
-    res_range (float)            :: Range of resolutions in target function in Angstroms
-    defocus_range (float)        :: Min, max and step size of initial defocus search in Angstroms
-    astigm_type (str)            :: Type of astigmatism. FLAG USE NOT RECOMMENDED
-    exhaustive_search (bool)     :: Use exhaustive search algorithm for defocus
-    astigm_restraint (int)       :: Restraint on astigmatism in Angstroms
-    phase_shift (bool)           :: Estimate phase shift
+    Args:
+        project_name (str): Name of current project
+        output_folder (str): Path to folder for storing CTFFind4 outputs
+        file_prefix (str): Common prefix of raw image files (Default: project)
+        exec_path (str): Path to IMOD executable
+        voltage (float): Electron beam voltage in keV
+        spherical_aberration (float): Spherical aberration of objective lens in mrad
+        amp_contrast (float): Relative amplitude contrast w1
+        res_range (float): Range of resolutions in target function in Angstroms
+        defocus_range (float): Min, max and step size of initial defocus search in Angstroms
+        astigm_type (str): Type of astigmatism. FLAG USE NOT RECOMMENDED
+        exhaustive_search (bool): Use exhaustive search algorithm for defocus
+        astigm_restraint (int): Restraint on astigmatism in Angstroms
+        phase_shift (bool): Estimate phase shift
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
 
     return locals()
@@ -311,36 +311,36 @@ def get_args_align(
     """
     Function to add arguments to parser for IMOD alignment
 
-    ARGS:
-    project_name (str)            :: Name of current project
-    rot_angle (float)             :: Rotational angle of electron beam. Can be obtained from MDOC files
-    image_dims (int)              :: Image dimensions (in pixels)
-    excl_views (int)              :: Indices of micrographes to be excluded
-    output_folder (str)           :: Path to folder for storing IMOD outputs
-    file_prefix (str)             :: Common prefix of raw image files (Default: project)
-    file_suffix (str)             :: Extra information attached as suffix to output filenames
-    no_rawtlt (bool)              :: Use information in filenames to determine tilt angles (rather than using .rawtlt files)
-    fiducial_size (float)         :: Size (in nm) of gold fiducial particles
-    adoc_template (str)           :: Path to template file of BatchRunTomo directives
-    stack_bin_factor (int)        :: Stack: Raw image stacks downsampling factor
-    delete_old_files (bool)       :: Preprocessing: Remove original stack when excluding views
-    remove_xrays (bool)           :: Preprocessing: Attempt to remove X-rays and other artefacts
-    coarse_align_bin_factor (int) :: Coarse-alignment: Coarse aligned stack binning
-    num_patches (int)             :: Patch-tracking: Number of patches to track in X and Y
-    patch_overlap (int)           :: Patch-tracking: % overlap between patches
-    num_iter (int)                :: Patch-tracking: Number of iterations. (Max. 4)
-    limits_on_shift (int)         :: Patch-tracking: Maximum extent (in pixels) to which patches are allowed to move during alignment
-    adjust_tilt_angles (bool)     :: Patch-tracking: Rerun patch-tracking procedure with tilt-angle offset
-    num_surfaces (int)            :: Fine-alignment: Number of surface(s) for angle analysis
-    mag_option (str)              :: Fine-alignment: Type of magnification solution
-    tilt_option (str)             :: Fine-alignment: Type of tilt-angle solution
-    rot_option (str)              :: Fine-alignment: Type of rotation solution
-    beam_tilt_option (str)        :: Fine-alignment: Type of beam-tilt solution
-    robust_fitting (bool)         :: Fine-alignment: Use robust fitting
-    weight_contours (bool)        :: Fine-alignment: Apply weighting to entire contours from patch-tracking
+    Args:
+        project_name (str): Name of current project
+        rot_angle (float): Rotational angle of electron beam. Can be obtained from MDOC files
+        image_dims (int): Image dimensions (in pixels)
+        excl_views (int): Indices of micrographes to be excluded
+        output_folder (str): Path to folder for storing IMOD outputs
+        file_prefix (str): Common prefix of raw image files (Default: project)
+        file_suffix (str): Extra information attached as suffix to output filenames
+        no_rawtlt (bool): Use information in filenames to determine tilt angles (rather than using .rawtlt files)
+        fiducial_size (float): Size (in nm) of gold fiducial particles
+        adoc_template (str): Path to template file of BatchRunTomo directives
+        stack_bin_factor (int): Stack: Raw image stacks downsampling factor
+        delete_old_files (bool): Preprocessing: Remove original stack when excluding views
+        remove_xrays (bool): Preprocessing: Attempt to remove X-rays and other artefacts
+        coarse_align_bin_factor (int): Coarse-alignment: Coarse aligned stack binning
+        num_patches (int): Patch-tracking: Number of patches to track in X and Y
+        patch_overlap (int): Patch-tracking: % overlap between patches
+        num_iter (int): Patch-tracking: Number of iterations. (Max. 4)
+        limits_on_shift (int): Patch-tracking: Maximum extent (in pixels) to which patches are allowed to move during alignment
+        adjust_tilt_angles (bool): Patch-tracking: Rerun patch-tracking procedure with tilt-angle offset
+        num_surfaces (int): Fine-alignment: Number of surface(s) for angle analysis
+        mag_option (str): Fine-alignment: Type of magnification solution
+        tilt_option (str): Fine-alignment: Type of tilt-angle solution
+        rot_option (str): Fine-alignment: Type of rotation solution
+        beam_tilt_option (str): Fine-alignment: Type of beam-tilt solution
+        robust_fitting (bool): Fine-alignment: Use robust fitting
+        weight_contours (bool): Fine-alignment: Apply weighting to entire contours from patch-tracking
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
 
     return locals()
@@ -443,38 +443,38 @@ def get_args_align_ext(
     """
     Function to add arguments to parser for IMOD alignment
 
-    ARGS:
-    project_name (str)            :: Name of current project
-    rot_angle (float)             :: Rotational angle of electron beam. Can be obtained from MDOC files
-    image_dims (int)              :: Image dimensions (in pixels)
-    pixel_size (float)            :: Image pixel size (in angstroms)
-    excl_views (int)              :: Indices of micrographes to be excluded
-    input_folder (str)            :: Path to folder with image stacks
-    output_folder (str)           :: Path to folder for storing IMOD outputs
-    file_prefix (str)             :: Common prefix of raw image files (Default: project)
-    file_suffix (str)             :: Extra information attached as suffix to output filenames
-    no_rawtlt (bool)              :: Use information in filenames to determine tilt angles (rather than using .rawtlt files)
-    fiducial_size (float)         :: Size (in nm) of gold fiducial particles
-    adoc_template (str)           :: Path to template file of BatchRunTomo directives
-    stack_bin_factor (int)        :: Stack: Raw image stacks downsampling factor
-    delete_old_files (bool)       :: Preprocessing: Remove original stack when excluding views
-    remove_xrays (bool)           :: Preprocessing: Attempt to remove X-rays and other artefacts
-    coarse_align_bin_factor (int) :: Coarse-alignment: Coarse aligned stack binning
-    num_patches (int)             :: Patch-tracking: Number of patches to track in X and Y
-    patch_overlap (int)           :: Patch-tracking: % overlap between patches
-    num_iter (int)                :: Patch-tracking: Number of iterations. (Max. 4)
-    limits_on_shift (int)         :: Patch-tracking: Maximum extent (in pixels) to which patches are allowed to move during alignment
-    adjust_tilt_angles (bool)     :: Patch-tracking: Rerun patch-tracking procedure with tilt-angle offset
-    num_surfaces (int)            :: Fine-alignment: Number of surface(s) for angle analysis
-    mag_option (str)              :: Fine-alignment: Type of magnification solution
-    tilt_option (str)             :: Fine-alignment: Type of tilt-angle solution
-    rot_option (str)              :: Fine-alignment: Type of rotation solution
-    beam_tilt_option (str)        :: Fine-alignment: Type of beam-tilt solution
-    robust_fitting (bool)         :: Fine-alignment: Use robust fitting
-    weight_contours (bool)        :: Fine-alignment: Apply weighting to entire contours from patch-tracking
+    Args:
+        project_name (str): Name of current project
+        rot_angle (float): Rotational angle of electron beam. Can be obtained from MDOC files
+        image_dims (int): Image dimensions (in pixels)
+        pixel_size (float): Image pixel size (in angstroms)
+        excl_views (int): Indices of micrographes to be excluded
+        input_folder (str): Path to folder with image stacks
+        output_folder (str): Path to folder for storing IMOD outputs
+        file_prefix (str): Common prefix of raw image files (Default: project)
+        file_suffix (str): Extra information attached as suffix to output filenames
+        no_rawtlt (bool): Use information in filenames to determine tilt angles (rather than using .rawtlt files)
+        fiducial_size (float): Size (in nm) of gold fiducial particles
+        adoc_template (str): Path to template file of BatchRunTomo directives
+        stack_bin_factor (int): Stack: Raw image stacks downsampling factor
+        delete_old_files (bool): Preprocessing: Remove original stack when excluding views
+        remove_xrays (bool): Preprocessing: Attempt to remove X-rays and other artefacts
+        coarse_align_bin_factor (int): Coarse-alignment: Coarse aligned stack binning
+        num_patches (int): Patch-tracking: Number of patches to track in X and Y
+        patch_overlap (int): Patch-tracking: % overlap between patches
+        num_iter (int): Patch-tracking: Number of iterations. (Max. 4)
+        limits_on_shift (int): Patch-tracking: Maximum extent (in pixels) to which patches are allowed to move during alignment
+        adjust_tilt_angles (bool): Patch-tracking: Rerun patch-tracking procedure with tilt-angle offset
+        num_surfaces (int): Fine-alignment: Number of surface(s) for angle analysis
+        mag_option (str): Fine-alignment: Type of magnification solution
+        tilt_option (str): Fine-alignment: Type of tilt-angle solution
+        rot_option (str): Fine-alignment: Type of rotation solution
+        beam_tilt_option (str): Fine-alignment: Type of beam-tilt solution
+        robust_fitting (bool): Fine-alignment: Use robust fitting
+        weight_contours (bool): Fine-alignment: Apply weighting to entire contours from patch-tracking
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
 
     return locals()
@@ -524,20 +524,20 @@ def get_args_recon(
     """
     Function to add arguments to parser for IMOD reconstruction
 
-    ARGS:
-    project_name (str)       :: Name of current project
-    do_positioning (bool)    :: Whether to perform positioning
-    unbinned_thickness (int) :: Unbinned thickness (in pixels) for samples or whole tomogram for positioning
-    correct_ctf (bool)       :: Whether to correct CTF for aligned stacks
-    erase_gold (bool)        :: Whether to erase gold fiducials
-    filtering (bool)         :: Whether to perform 2D filtering
-    bin_factor (int)         :: Binning factor for aligned stack
-    thickness (int)          :: Thickness (in pixels) for reconstruction
-    trimvol (bool)           :: Run Trimvol on reconstruction
-    trimvol_reorient (str)   :: Reorientation in Trimvol
+    Args:
+        project_name (str): Name of current project
+        do_positioning (bool): Whether to perform positioning
+        unbinned_thickness (int): Unbinned thickness (in pixels) for samples or whole tomogram for positioning
+        correct_ctf (bool): Whether to correct CTF for aligned stacks
+        erase_gold (bool): Whether to erase gold fiducials
+        filtering (bool): Whether to perform 2D filtering
+        bin_factor (int): Binning factor for aligned stack
+        thickness (int): Thickness (in pixels) for reconstruction
+        trimvol (bool): Run Trimvol on reconstruction
+        trimvol_reorient (str): Reorientation in Trimvol
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     return locals()
 
@@ -571,15 +571,15 @@ def get_args_ctfsim(
     """
     Function to add arguments to parser for O2R-CTFsim
 
-    ARGS:
-    project_name (str) :: Name of current project
-    pixel_res (float)  :: Pixel resolution of motion-corrected images (in Angstroms)
-    ds_factor (int)    :: Downsampling factor (must be same as alignment/reconstruction)
-    rootname (str)     :: Rootname of project (if different from project name)
-    dims (int*2)       :: Dimensions of simulated CTF (in pixels)
+    Args:
+        project_name (str): Name of current project
+        pixel_res (float): Pixel resolution of motion-corrected images (in Angstroms)
+        ds_factor (int): Downsampling factor (must be same as alignment/reconstruction)
+        rootname (str): Rootname of project (if different from project name)
+        dims (int*2): Dimensions of simulated CTF (in pixels)
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
 
     return locals()
@@ -631,19 +631,19 @@ def get_args_rldeconv(
     """
     Function to add arguments to parser for RedLionfish deconvolution
 
-    ARGS:
-    image_path (str) :: Path to raw image
-    image_type (str) :: File type of raw image
-    psf_path (str) :: Path to PSF for deconvolution
-    psf_type (str) :: File type of PSF stack
-    output_path (str) :: Path to deconvolved image
-    device (str) :: Device used for deconvolution
-    niter (int) :: Max number of iteration in deconvolution
-    block (bool) :: Whether to use block iterative algorithm for deconvolution
-    uint (int) :: Whether to encode results as UInt8
+    Args:
+        image_path (str): Path to raw image
+        image_type (str): File type of raw image
+        psf_path (str): Path to PSF for deconvolution
+        psf_type (str): File type of PSF stack
+        output_path (str): Path to deconvolved image
+        device (str): Device used for deconvolution
+        niter (int): Max number of iteration in deconvolution
+        block (bool): Whether to use block iterative algorithm for deconvolution
+        uint (int): Whether to encode results as UInt8
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
 
     return locals()
@@ -687,11 +687,11 @@ def get_args_savurecon(
     """
     Function to add arguments to parser for Savu reconstruction
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
 
     return locals()
@@ -750,11 +750,11 @@ def get_args_imod_route(
     """
     Function to get essential parameters for processing steps on IMOD route
 
-    ARGS:
+    Args:
+        None
 
-
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
 
     return locals()

--- a/src/Ot2Rec/metadata.py
+++ b/src/Ot2Rec/metadata.py
@@ -51,10 +51,11 @@ class Metadata:
         """
         Initialise Metadata object
 
-        ARGS:
-        project_name :: project name
-        job_type     :: what job is being done (motioncorr/ctffind/align/reconstruct)
-        md_in        :: dictionary read from yaml file containing existing metadata
+        Args:
+            project_name: project name
+            job_type: what job is being done 
+                (motioncorr/ctffind/align/reconstruct)
+            md_in: dictionary read from yaml file containing existing metadata
         """
 
         self.project_name = project_name
@@ -162,8 +163,11 @@ class Metadata:
     @staticmethod
     def get_num_frames(curr_file, target_frames):
         """
-        curr_file (str)     :: path to current file
-        target_frames (int) :: target number of frames in the 'mrc'
+        Get number of frames from the micrograph
+
+        Args:
+            curr_file (str): path to current file
+            target_frames (int): target number of frames in the 'mrc'
         """
 
         command = ["header", curr_file]
@@ -182,8 +186,9 @@ class Metadata:
     @staticmethod
     def get_num_frames_parallel(func, filelist, target_frames=15, np=8):
         """
-        func (func)     :: function to be parallelised
-        filelist (list) :: list of image files to be passed into the function
+        Args:
+            func (func): function to be parallelised
+            filelist (list): list of image files to be passed into the function
         """
         func_filelist = partial(func, target_frames=target_frames)
         with mp.Pool(np) as p:
@@ -266,13 +271,13 @@ def read_md_yaml(project_name: str,
     """
     Function to read in YAML file containing metadata
 
-    ARGS:
-    project_name :: Name of current project
-    job_type     :: what job is being done (motioncorr/ctffind/align/reconstruct)
-    filename     :: Name of the YAML file to be read
+    Args:
+        project_name: Name of current project
+        job_type: what job is being done (motioncorr/ctffind/align/reconstruct)
+        filename: Name of the YAML file to be read
 
-    RETURNS:
-    Metadata object
+    Returns:
+        ot2rec.metadata.Metadata
     """
 
     # Check if file exists

--- a/src/Ot2Rec/motioncorr.py
+++ b/src/Ot2Rec/motioncorr.py
@@ -37,11 +37,11 @@ class Motioncorr:
         """
         Initialise Motioncorr object
 
-        ARGS:
-        project_name (str)  :: Name of current project
-        mc2_params (Params) :: Parameters read in from yaml file
-        md_in (Metadata)    :: Metadata containing information of images
-        logger (Logger)     :: Logger for recording events
+        Args:
+            project_name (str): Name of current project.
+            mc2_params (Params): Parameters read in from yaml file.
+            md_in (Metadata): Metadata containing information of images.
+            logger (Logger): Logger for recording events.
         """
 
         self.proj_name = project_name
@@ -186,12 +186,12 @@ class Motioncorr:
         """
         Subroutine to get commands for running MotionCor2
 
-        ARGS:
-        image (tuple)      :: metadata for current image (in_path, out_path, #GPU)
-        extra_info (tuple) :: extra information (#EER frames, binning factor, frame dose rate)
+        Args:
+            image (tuple)      : metadata for current image (in_path, out_path, #GPU)
+            extra_info (tuple) : extra information (#EER frames, binning factor, frame dose rate)
 
-        RETURNS:
-        list
+        Returns:
+            list
         """
 
         in_path, out_path, gpu_number = image
@@ -338,8 +338,8 @@ def update_yaml(args):
     """
     Subroutine to update yaml file for motioncorr
 
-    ARGS:
-    args (Namespace) :: Arguments obtained from user
+    Args:
+        args (Namespace) : Arguments obtained from user
     """
     logger = logMod.Logger(log_path="o2r_motioncor2.log")
 

--- a/src/Ot2Rec/params.py
+++ b/src/Ot2Rec/params.py
@@ -30,9 +30,9 @@ class Params:
         """
         Initialise Params object
 
-        ARGS:
-        project_name :: Name of current project
-        params_in    :: Parameters being read in
+        Args:
+            project_name: Name of current project
+            params_in: Parameters being read in
         """
 
         self.project_name = project_name
@@ -43,8 +43,8 @@ def new_master_yaml(args):
     """
     Subroutine to create yaml file for processing master metadata
 
-    ARGS:
-    args (Namespace) :: Namespace generated with user inputs
+    Args:
+        args (Namespace): Namespace generated with user inputs
     """
 
     master_yaml_name = args.project_name.value + '_proj.yaml'
@@ -67,8 +67,8 @@ def new_mc2_yaml(args):
     """
     Subroutine to create yaml file for motioncorr
 
-    ARGS:
-    args (Namespace) :: Namespace generated with user inputs
+    Args:
+        args (Namespace): Namespace generated with user inputs
     """
 
     mc2_yaml_name = args.project_name.value + '_mc2.yaml'
@@ -104,8 +104,8 @@ def new_ctffind_yaml(args):
     """
     Subroutine to create yaml file for ctffind
 
-    ARGS:
-    args (Namespace) :: Namespace generated with user inputs
+    Args:
+        args (Namespace): Namespace generated with user inputs
     """
 
     ctf_yaml_name = args.project_name.value + '_ctffind.yaml'
@@ -143,8 +143,8 @@ def new_align_yaml(args):
     """
     Subroutine to create yaml file for stack creation and BatchTomo (up till alignment)
 
-    ARGS:
-    args (Namespace) :: Namespace generated with user inputs
+    Args:
+        args (Namespace): Namespace generated with user inputs
     """
 
     # Calculate patch sizes
@@ -214,8 +214,8 @@ def new_recon_yaml(args):
     """
     Subroutine to create yaml file for batchtomo (continuing from aligned stacks to full reconstruction)
 
-    ARGS:
-    args (Namespace) :: Namespace generated with user inputs
+    Args:
+        args (Namespace): Namespace generated with user inputs
     """
     recon_yaml_name = args.project_name.value + '_recon.yaml'
 
@@ -269,8 +269,8 @@ def new_savurecon_yaml(args):
     """
     Subroutine to create yaml file for savurecon (continuing from aligned stacks to full reconstruction)
 
-    ARGS:
-    args (Namespace) :: Namespace containing user parameter inputs
+    Args:
+        args (Namespace): Namespace containing user parameter inputs
     """
 
     savurecon_yaml_name = args.project_name.value + '_savurecon.yaml'
@@ -301,8 +301,8 @@ def new_aretomo_yaml(args):
     """
     Subroutine to create yaml file for aretomo
 
-    ARGS:
-    args (Namespace) :: Namespace containing user parameter inputs
+    Args:
+        args (Namespace): Namespace containing user parameter inputs
     """
 
     aretomo_yaml_names = {0: args["project_name"] + "_aretomo_align.yaml",
@@ -352,8 +352,8 @@ def new_exclude_bad_tilts_yaml(args):
     """
     Subroutine to create yaml file for excluding bad tilts
 
-    ARGS:
-    args (Namespace) :: Namespace containing user parameter inputs
+    Args:
+        args (Namespace): Namespace containing user parameter inputs
     """
 
     ebt_yaml_name = f"{args.project_name.value}_exclude_bad_tilts.yaml"
@@ -380,12 +380,12 @@ def read_yaml(project_name: str,
     """
     Function to read in config file
 
-    ARGS:
-    project_name :: name of current project
-    filename     :: config file name
+    Args:
+        project_name: name of current project
+        filename: config file name
 
-    RETURNS:
-    Params object
+    Returns:
+        ot2rec.params.Params
     """
 
     # Check if file exists

--- a/src/Ot2Rec/recon.py
+++ b/src/Ot2Rec/recon.py
@@ -42,11 +42,11 @@ class Recon:
         """
         Initialising a Recon object
 
-        ARGS:
-        project_name (str) :: name of current project
-        md_in (Metadata)   :: metadata containing images to be put into stack(s) for alignment
-        params_in (Params) :: parameters for stack creation
-        logger_in (Logger) :: logger object to keep record of progress and errors
+        Args:
+            project_name (str): name of current project
+            md_in (Metadata): metadata containing images to be put into stack(s) for alignment
+            params_in (Params): parameters for stack creation
+            logger_in (Logger): logger object to keep record of progress and errors
         """
 
         self.proj_name = project_name
@@ -218,11 +218,11 @@ runtime.Trimvol.any.reorient = <trimvol_reorient>
         """
         Method to get command to run batchtomo for reconstruction
 
-        ARGS:
-        curr_ts :: index of the tilt-series currently being processed
+        Args:
+            curr_ts: index of the tilt-series currently being processed
 
-        RETURNS:
-        list
+        Returns:
+            list
         """
 
         # Get indices of usable CPUs
@@ -348,8 +348,8 @@ def update_yaml(args):
     """
     Subroutine to update yaml file for IMOD reconstruction
 
-    ARGS:
-    args (Namespace) :: Namespace generated with user inputs
+    Args:
+        args (Namespace): Namespace generated with user inputs
     """
     logger = logMod.Logger(log_path="o2r_imod_recon.log")
 

--- a/src/Ot2Rec/rlf_deconv.py
+++ b/src/Ot2Rec/rlf_deconv.py
@@ -45,14 +45,14 @@ class RLF_deconv():
         """
         Initialise the RLF_deconv object
 
-        ARGS:
-        rootname (str)          :: rootname of project
-        orig_folder (ndarray)   :: parent folder containing original images to be deconvolved
-        kernel_folder (ndarray) :: parent folder containing kernel with which the image is to be deconvolved
-        out_folder (ndarray)    :: output parent folder for deconvolved tomograms
-        params_dict (dict)      :: dictionary containing all parameters used in RLF
-        orig_mrc (bool)         :: whether the original image is in MRC format (TIFF if false)
-        kernel_mrc (bool)       :: whether the kernel is in MRC format (TIFF if false)
+        Args:
+            rootname (str): rootname of project
+            orig_folder (ndarray): parent folder containing original images to be deconvolved
+            kernel_folder (ndarray): parent folder containing kernel with which the image is to be deconvolved
+            out_folder (ndarray): output parent folder for deconvolved tomograms
+            params_dict (dict): dictionary containing all parameters used in RLF
+            orig_mrc (bool): whether the original image is in MRC format (TIFF if false)
+            kernel_mrc (bool): whether the kernel is in MRC format (TIFF if false)
         """
         self.rootname = rootname
         self.suffix = suffix
@@ -120,7 +120,7 @@ class RLF_deconv():
         Method to read an MRC file and return a numpy array
 
         Returns:
-        ndarray
+            ndarray
         """
         with mrcfile.open(path) as image:
             data = image.data
@@ -134,7 +134,7 @@ class RLF_deconv():
         Method to read a TIFF file and return a numpy array
 
         Returns:
-        ndarray
+            ndarray
         """
         data = tifffile.imread(path)
 

--- a/src/Ot2Rec/savurecon.py
+++ b/src/Ot2Rec/savurecon.py
@@ -41,10 +41,11 @@ class SavuRecon:
                  ):
         """
         Initialising a SavuRecon object
-        ARGS:
-        project_name (str) :: name of current project
-        params_in (Params) :: parameters for stack creation
-        logger_in (Logger) :: logger object to keep record of progress and errors
+
+        Args:
+            project_name (str): name of current project
+            params_in (Params): parameters for stack creation
+            logger_in (Logger): logger object to keep record of progress and errors
         """
 
         self.proj_name = project_name
@@ -87,8 +88,9 @@ class SavuRecon:
     def _get_savuconfig_recon_command(self, i):
         """
         Method to get command to set up Savu process list
-        ARGS:
-        i (int): The i-th tilt series to process
+        
+        Args:
+            i (int): The i-th tilt series to process
         """
 
         curr_ts = self.params['System']['process_list'][i]
@@ -250,8 +252,9 @@ def create_yaml(args=None):
 def update_yaml(args):
     """
     Method to update yaml file for savu reconstruction --- if stacks already exist
+    
     Args:
-    args (Namespace) :: Namespace containing user inputs
+        args (Namespace): Namespace containing user inputs
     """
     logger = logMod.Logger(log_path="o2r_savu_recon.log")
 

--- a/src/Ot2Rec/user_args.py
+++ b/src/Ot2Rec/user_args.py
@@ -8,7 +8,7 @@
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,::
 # either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
@@ -18,13 +18,13 @@ import argparse
 
 def get_args_new_proj():
     """
-    Function to add arguments to parser for new project
+    (DEPRECATED) Function to add arguments to parser for new project
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("project_name",
@@ -67,13 +67,13 @@ def get_args_new_proj():
 
 def get_args_mc2():
     """
-    Function to add arguments to parser for MotionCor
+    (DEPRECATED) Function to add arguments to parser for MotionCor
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("project_name",
@@ -141,13 +141,13 @@ def get_args_mc2():
 
 def get_args_ctffind():
     """
-    Function to add arguments to parser for CTFFind
+    (DEPRECATED) Function to add arguments to parser for CTFFind
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("project_name",
@@ -209,13 +209,13 @@ def get_args_ctffind():
 
 def get_args_align():
     """
-    Function to add arguments to parser for IMOD alignment
+    (DEPRECATED) Function to add arguments to parser for IMOD alignment
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("project_name",
@@ -323,13 +323,13 @@ def get_args_align():
 
 def get_args_align_ext():
     """
-    Function to add arguments to parser for IMOD alignment (with external image stacks)
+    (DEPRECATED) Function to add arguments to parser for IMOD alignment (with external image stacks)
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("project_name",
@@ -443,13 +443,13 @@ def get_args_align_ext():
 
 def get_args_recon():
     """
-    Function to add arguments to parser for IMOD reconstruction
+    (DEPRECATED) Function to add arguments to parser for IMOD reconstruction
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("project_name",
@@ -491,13 +491,13 @@ def get_args_recon():
 
 def get_args_ctfsim():
     """
-    Function to add arguments to parser for O2R-CTFsim
+    (DEPRECATED) Function to add arguments to parser for O2R-CTFsim
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("project_name",
@@ -523,13 +523,13 @@ def get_args_ctfsim():
 
 def get_args_savurecon():
     """
-    Function to add arguments to parser for Savu reconstruction
+    (DEPRECATED) Function to add arguments to parser for Savu reconstruction
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("project_name",
@@ -564,13 +564,13 @@ def get_args_savurecon():
 
 def get_args_rldeconv():
     """
-    Function to add arguments to parser for RedLionfish deconvolution
+    (DEPRECATED) Function to add arguments to parser for RedLionfish deconvolution
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
+    Returns:
+        Namespace
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("image_path",
@@ -613,14 +613,14 @@ def get_args_rldeconv():
 
 def get_args_aretomo():
     """
-    Function to add arguments to parser for AreTomo
+    (DEPRECATED) Function to add arguments to parser for AreTomo
 
-    ARGS:
-    None
+    Args:
+        None
 
-    OUTPUTs:
-    Namespace
-    kwargs (list) : list of extra parameters to pass to AreTomo, empty if none are passed
+    Returns:
+        Namespace
+        kwargs (list) : list of extra parameters to pass to AreTomo, empty if none are passed
 
     """
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Changed all docstrings to follow Google style properly, sets up GH actions to automatically generate API docs from the `dev` branch. 

API docs are generated with [pdoc](https://pdoc.dev/).